### PR TITLE
feat: Update Terraform configuration for enhanced security and examples

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -3,8 +3,7 @@ formatter: "md" # this is required
 version: ">= 0.16.0, < 1.0.0"
 
 recursive:
-  enabled: true
-  path: examples
+  enabled: false
 
 content: |-
   {{ .Header }}
@@ -17,10 +16,10 @@ content: |-
   {{ include "examples/quickstart/main.tf" }}
   ```
 
-  ### Community
+  ### Advanced Example
 
   ```hcl
-  {{ include "examples/community/main.tf" }}
+  {{ include "examples/advanced/main.tf" }}
   ```
 
   {{ .Inputs }}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Visit [containers.dev](https://containers.dev) for more information
 
 - You can use local Terraform state for demo purposes
 - We recommend to [Store Terraform state in Azure Storage](https://learn.microsoft.com/en-us/azure/developer/terraform/store-state-in-azure-storage?tabs=azure-cli) for your Production environment
+
+## Security defaults
+
+- Storage account public network access and shared key authorization are disabled out of the box.
+- A storage account SAS expiration policy defaults to 24 hours and can be adjusted through `storage_account_sas_expiration_period`.
+- Optional inputs allow enabling trusted Microsoft services or soft-delete retention when required.
+- Because shared keys are disabled, Terraform must use Azure AD for all storage data plane operations. Set `storage_use_azuread = true` in your provider configuration (or export `ARM_STORAGE_USE_AZUREAD=true`) and assign your deployment principal the roles `Storage Queue Data Contributor` and `Storage Table Data Contributor` on the storage account.
+
 <!-- BEGIN_TF_DOCS -->
 
 
@@ -56,7 +64,9 @@ terraform {
 
 provider "azurerm" {
   features {}
-  partner_id = "a262352f-52a9-4ed9-a9ba-6a2b2478d19b"
+  storage_use_azuread = true
+  partner_id          = "a262352f-52a9-4ed9-a9ba-6a2b2478d19b"
+  subscription_id     = var.subscription_id
 }
 
 # Resources
@@ -76,15 +86,16 @@ module "scepman" {
   source = "scepman/scepman/azurerm"
   # version = "0.1.0"
 
-
+  organization_name   = var.organization_name
   resource_group_name = azurerm_resource_group.rg.name
   location            = var.location
 
-  storage_account_name = var.storage_account_name
-  key_vault_name       = var.key_vault_name
-  law_name             = var.law_name
+  storage_account_name                     = var.storage_account_name
+  key_vault_name                           = var.key_vault_name
+  law_name                                 = var.law_name
+  storage_account_managed_identity_enabled = var.storage_account_managed_identity_enabled
 
-  service_plan_os_type                = "Windows"
+  service_plan_os_type                = var.service_plan_os_type
   service_plan_name                   = var.service_plan_name
   app_service_name_primary            = var.app_service_name_primary
   app_service_name_certificate_master = var.app_service_name_certificate_master
@@ -92,58 +103,65 @@ module "scepman" {
   app_settings_primary            = var.app_settings_primary
   app_settings_certificate_master = var.app_settings_certificate_master
 
+  enable_application_insights = var.enable_application_insights
+
   tags = var.tags
 }
 ```
 
 ## Inputs
 
-| Name                                                                                                                                                | Description                                                               | Type          | Default                                                                                               | Required |
-| --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------- | :------: |
-| <a name="input_app_service_name_certificate_master"></a> [app\_service\_name\_certificate\_master](#input\_app\_service\_name\_certificate\_master) | Name of the certificate master app service                                | `string`      | n/a                                                                                                   |   yes    |
-| <a name="input_app_service_name_primary"></a> [app\_service\_name\_primary](#input\_app\_service\_name\_primary)                                    | Name of the primary app service                                           | `string`      | n/a                                                                                                   |   yes    |
-| <a name="input_app_service_minimum_tls_version_scepman"></a> [app\_service\_minimum\_tls\_version\_scepman](#input\_app\_service\_minimum\_tls\_version\_scepman) | Minimum Inbound TLS Version for SCEPman core App Service                 | `string`      | `1.2`                                                                                                  |    no    |
-| <a name="input_app_service_minimum_tls_version_certificate_master"></a> [app\_service\_minimum\_tls\_version\_certificate\_master](#input\_app\_service\_minimum\_tls\_version\_certificate\_master) | Minimum Inbound TLS Version for Certificate Master App Service           | `string`      | `1.3`                                                                                                  |    no    |
-| <a name="input_app_settings_certificate_master"></a> [app\_settings\_certificate\_master](#input\_app\_settings\_certificate\_master)               | A mapping of app settings to assign to the certificate master app service | `map(string)` | `{}`                                                                                                  |    no    |
-| <a name="input_app_settings_primary"></a> [app\_settings\_primary](#input\_app\_settings\_primary)                                                  | A mapping of app settings to assign to the primary app service            | `map(string)` | `{}`                                                                                                  |    no    |
-| <a name="input_artifacts_url_primary"></a> [artifacts\_url\_primary](#input\_artifacts\_url\_primary)                                               | URL to the artifacts of the primary SCEPman Service                       | `string`      | `"https://raw.githubusercontent.com/scepman/install/master/dist/Artifacts.zip"`                       |    no    |
-| <a name="input_artifacts_url_certificate_master"></a> [artifacts\_url\_certificate\_master](#input\_artifacts\_url\_certificate\_master)            | URL to the artifacts of the SCEPman certificate master                    | `string`      | `"https://raw.githubusercontent.com/scepman/install/master/dist-certmaster/CertMaster-Artifacts.zip"` |    no    |
-| <a name="input_law_name"></a> [law\_name](#input\_law\_name)                                                                                        | Name of the Log Analytics Workspace                                       | `string`      | n/a                                                                                                   |   yes    |
-| <a name="input_law_resource_group"></a> [law\_resource\_group](#input\_law\_resource\_group)                                                        | Resource Group of existing Log Analytics Workspace                        | `string`      | `null`                                                                                                |    no    |
-| <a name="input_key_vault_name"></a> [key\_vault\_name](#input\_key\_vault\_name)                                                                    | Name of the key vault                                                     | `string`      | n/a                                                                                                   |   yes    |
-| <a name="input_vnet_name"></a> [vnet\_name](#input\_vnet\_name)                                                                                     | Name of VNET created for internal communication                           | `string`      | vnet-scepman                                                                                          |    no    |
-| <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space)                                                        | Address-Space of the VNET (needs to be /27 or larger)                                                 | `list(any)`   | ["10.158.200.0/24"]                                                                                   |    no    |
-| <a name="input_subnet_appservices_name"></a> [subnet\_appservices\_name](#input\_subnet\_appservices\_name)                                         | Name of the subnet created for integrating the App Services               | `string`      | snet-scepman-appservices                                                                              |    no    |
-| <a name="input_subnet_endpoints_name"></a> [subnet\_endpoints\_name](#input\_subnet\_endpoints\_name)                                               | Name of the subnet created for the other endpoints                        | `string`      | snet-scepman-endpoints                                                                                |    no    |
-| <a name="input_location"></a> [location](#input\_location)                                                                                          | Azure Region where the resources should be created                        | `string`      | n/a                                                                                                   |   yes    |
-| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name)                                                     | Name of the resource group                                                | `string`      | n/a                                                                                                   |   yes    |
-| <a name="input_service_plan_name"></a> [service\_plan\_name](#input\_service\_plan\_name)                                                           | Name of the service plan                                                  | `string`      | n/a                                                                                                   |   yes    |
-| <a name="input_service_plan_os_type"></a> [service\_plan\_os\_type](#input\_service\_plan\_os\_type)                                                              | OS of the service plan. Either "Windows" or "Linux"                                                   | `string`      | `Windows`                                                                                                  |    no    |
-| <a name="input_service_plan_sku"></a> [service\_plan\_sku](#input\_service\_plan\_sku)                                                              | SKU of the service plan                                                   | `string`      | `S1`                                                                                                  |    no    |
-| <a name="input_service_plan_resource_id"></a> [service\_plan\_resource\_id](#input\_service\_plan\_resource\_id)                                    | Resource ID of the service plan                                           | `string`      | `null`                                                                                                |    no    |
-| <a name="input_storage_account_name"></a> [storage\_account\_name](#input\_storage\_account\_name)                                                  | Name of the storage account                                               | `string`      | n/a                                                                                                   |   yes    |
-| <a name="input_storage_account_replication_type"></a> [storage\_account\_replication\_type](#input\_storage\_account\_replication\_type)           | Storage account replication type. Valid options are LRS, ZRS, GRS, RAGRS, GZRS, RAGZRS. | `string`      | `LRS`                                                                                                 |    no    |
-| <a name="input_organization_name"></a> [organization\_name](#input\organization\_name)                                                              | Your organization name presented in the O= field of the root certificate  | `string`      | `my-org`                                                                                              |    no    |
-| <a name="input_key_vault_use_rbac"></a> [key\_vault\_use\_rbac](#input\_key\_vault\_use\_rbac)                                                        | Use RBAC for the key vault or the older access policies                   | `bool`        | `true`                                                                                                |    no    |
-| <a name="input_tags"></a> [tags](#input\_tags)                                                                                                      | A mapping of tags to assign to the resource                               | `map(string)` | `{}`                                                                                                  |    no    |
-
-
-### Optional App Service Logging settings
-
-| Name                                                                                                                                                                                     | Description                                                                                                                                      | Type     | Default   | Required |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | --------- | :------: |
-| <a name="input_enable_application_insights"></a> [enable\_application\_insights](#input\_enable\_application\_insights)                                                                  | Create and connect Application Insights for the App services. NOTE: This will prevent Terraform from beeing able to destroy the ressource group! | `bool`   | `false`   |    no    |
-| <a name="input_app_service_retention_in_days"></a> [app\_service\_retention\_in\_days](#input\_app\_service\_retention\_in\_days)                                                        | Retention of http_logs in days                                                                                                                   | `number` | `180`     |    no    |
-| <a name="input_app_service_retention_in_mb"></a> [app\_service\_retention\_in\_mb](#input\_app\_service\_retention\_in\_mb)                                                              | Retention of http_logs in mb                                                                                                                     | `number` | `35`      |    no    |
-| <a name="input_app_service_logs_detailed_error_messages"></a> [app\_service\_logs\_detailed\_error\_messages](#input\_app\_service\_logs\_detailed\_error\_messages)                     | Detailed Error messages of the app service                                                                                                       | `bool`   | `true`    |    no    |
-| <a name="input_app_service_logs_failed_request_tracing"></a> [app\_service\_logs\_failed\_request\_tracing](#input\_app\_service\_logs\_failed\_request\_tracing)                        | Trace failed requests                                                                                                                            | `bool`   | `false`   |    no    |
-| <a name="input_app_service_application_logs_file_system_level"></a> [app\_service\_application\_logs\_file\_system\_level](#input\_app\_service\_application\_logs\_file\_system\_level) | Application Log level for file_system                                                                                                            | `string` | `"Error"` |    no    |
-
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_service_application_logs_file_system_level"></a> [app\_service\_application\_logs\_file\_system\_level](#input\_app\_service\_application\_logs\_file\_system\_level) | Application Log level for file\_system | `string` | `"Error"` | no |
+| <a name="input_app_service_logs_detailed_error_messages"></a> [app\_service\_logs\_detailed\_error\_messages](#input\_app\_service\_logs\_detailed\_error\_messages) | Detailed Error messages of the app service | `bool` | `true` | no |
+| <a name="input_app_service_logs_failed_request_tracing"></a> [app\_service\_logs\_failed\_request\_tracing](#input\_app\_service\_logs\_failed\_request\_tracing) | Trace failed requests | `bool` | `false` | no |
+| <a name="input_app_service_minimum_tls_version_certificate_master"></a> [app\_service\_minimum\_tls\_version\_certificate\_master](#input\_app\_service\_minimum\_tls\_version\_certificate\_master) | Minimum Inbound TLS Version for Certificate Master App Service | `string` | `"1.3"` | no |
+| <a name="input_app_service_minimum_tls_version_scepman"></a> [app\_service\_minimum\_tls\_version\_scepman](#input\_app\_service\_minimum\_tls\_version\_scepman) | Minimum Inbound TLS Version for SCEPman core App Service | `string` | `"1.2"` | no |
+| <a name="input_app_service_name_certificate_master"></a> [app\_service\_name\_certificate\_master](#input\_app\_service\_name\_certificate\_master) | Name of the certificate master app service | `string` | n/a | yes |
+| <a name="input_app_service_name_primary"></a> [app\_service\_name\_primary](#input\_app\_service\_name\_primary) | Name of the primary app service | `string` | n/a | yes |
+| <a name="input_app_service_retention_in_days"></a> [app\_service\_retention\_in\_days](#input\_app\_service\_retention\_in\_days) | How many days http\_logs should be kept | `number` | `90` | no |
+| <a name="input_app_service_retention_in_mb"></a> [app\_service\_retention\_in\_mb](#input\_app\_service\_retention\_in\_mb) | Max file size of http\_logs | `number` | `35` | no |
+| <a name="input_app_settings_certificate_master"></a> [app\_settings\_certificate\_master](#input\_app\_settings\_certificate\_master) | A mapping of app settings to assign to the certificate master app service | `map(string)` | `{}` | no |
+| <a name="input_app_settings_primary"></a> [app\_settings\_primary](#input\_app\_settings\_primary) | A mapping of app settings to assign to the primary app service | `map(string)` | `{}` | no |
+| <a name="input_artifacts_url_certificate_master"></a> [artifacts\_url\_certificate\_master](#input\_artifacts\_url\_certificate\_master) | URL of the artifacts for SCEPman Certificate Master | `string` | `"https://raw.githubusercontent.com/scepman/install/master/dist-certmaster/CertMaster-Artifacts.zip"` | no |
+| <a name="input_artifacts_url_primary"></a> [artifacts\_url\_primary](#input\_artifacts\_url\_primary) | URL of the artifacts for SCEPman | `string` | `"https://raw.githubusercontent.com/scepman/install/master/dist/Artifacts.zip"` | no |
+| <a name="input_enable_application_insights"></a> [enable\_application\_insights](#input\_enable\_application\_insights) | Should Terraform create and connect Application Insights for the App services? NOTE: This will prevent Terraform from beeing able to destroy the ressource group! | `bool` | `false` | no |
+| <a name="input_key_vault_name"></a> [key\_vault\_name](#input\_key\_vault\_name) | Name of the key vault | `string` | n/a | yes |
+| <a name="input_key_vault_use_rbac"></a> [key\_vault\_use\_rbac](#input\_key\_vault\_use\_rbac) | Use RBAC for the key vault or the older access policies | `bool` | `true` | no |
+| <a name="input_law_name"></a> [law\_name](#input\_law\_name) | Name for the Log Analytics Workspace | `string` | n/a | yes |
+| <a name="input_law_resource_group_name"></a> [law\_resource\_group\_name](#input\_law\_resource\_group\_name) | Ressource Group of existing Log Analytics Workspace | `string` | `null` | no |
+| <a name="input_location"></a> [location](#input\_location) | Azure Region where the resources should be created | `string` | n/a | yes |
+| <a name="input_organization_name"></a> [organization\_name](#input\_organization\_name) | Organization name (O=<my-org>) | `string` | `"my-org"` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group | `string` | n/a | yes |
+| <a name="input_service_plan_name"></a> [service\_plan\_name](#input\_service\_plan\_name) | Name of the service plan | `string` | n/a | yes |
+| <a name="input_service_plan_os_type"></a> [service\_plan\_os\_type](#input\_service\_plan\_os\_type) | The type of operating system to use for the app service plan. Possible values are 'Windows' or 'Linux'. | `string` | `"Windows"` | no |
+| <a name="input_service_plan_resource_id"></a> [service\_plan\_resource\_id](#input\_service\_plan\_resource\_id) | Resource ID of the service plan | `string` | `null` | no |
+| <a name="input_service_plan_sku"></a> [service\_plan\_sku](#input\_service\_plan\_sku) | SKU for App Service Plan | `string` | `"S1"` | no |
+| <a name="input_storage_account_allow_nested_items_to_be_public"></a> [storage\_account\_allow\_nested\_items\_to\_be\_public](#input\_storage\_account\_allow\_nested\_items\_to\_be\_public) | Allow nested items (containers/directories) to inherit public access. | `bool` | `false` | no |
+| <a name="input_storage_account_blob_soft_delete_retention_days"></a> [storage\_account\_blob\_soft\_delete\_retention\_days](#input\_storage\_account\_blob\_soft\_delete\_retention\_days) | Retention in days for blob soft delete. Set to 0 to keep soft delete disabled. | `number` | `7` | no |
+| <a name="input_storage_account_container_soft_delete_retention_days"></a> [storage\_account\_container\_soft\_delete\_retention\_days](#input\_storage\_account\_container\_soft\_delete\_retention\_days) | Retention in days for container soft delete. Set to 0 to keep soft delete disabled. | `number` | `7` | no |
+| <a name="input_storage_account_managed_identity_enabled"></a> [storage\_account\_managed\_identity\_enabled](#input\_storage\_account\_managed\_identity\_enabled) | Assign a system managed identity to the storage account to support Customer Managed Keys. | `bool` | `false` | no |
+| <a name="input_storage_account_min_tls_version"></a> [storage\_account\_min\_tls\_version](#input\_storage\_account\_min\_tls\_version) | Minimum TLS version for the storage account endpoint. | `string` | `"TLS1_2"` | no |
+| <a name="input_storage_account_name"></a> [storage\_account\_name](#input\_storage\_account\_name) | Name of the storage account | `string` | n/a | yes |
+| <a name="input_storage_account_public_network_access_enabled"></a> [storage\_account\_public\_network\_access\_enabled](#input\_storage\_account\_public\_network\_access\_enabled) | Allow public network access to the storage account. Default disables external access to rely on private endpoints. | `bool` | `false` | no |
+| <a name="input_storage_account_replication_type"></a> [storage\_account\_replication\_type](#input\_storage\_account\_replication\_type) | Storage account replication type. Valid options are LRS, ZRS, GRS, RAGRS, GZRS, RAGZRS. | `string` | `"LRS"` | no |
+| <a name="input_storage_account_sas_expiration_period"></a> [storage\_account\_sas\_expiration\_period](#input\_storage\_account\_sas\_expiration\_period) | Default expiration period applied to user delegation and service SAS tokens in d.hh:mm:ss format. | `string` | `"1.00:00:00"` | no |
+| <a name="input_storage_account_shared_access_key_enabled"></a> [storage\_account\_shared\_access\_key\_enabled](#input\_storage\_account\_shared\_access\_key\_enabled) | Enable shared access key authentication for the storage account. Default is false to enforce more secure authentication methods. | `bool` | `false` | no |
+| <a name="input_storage_account_trusted_services_enabled"></a> [storage\_account\_trusted\_services\_enabled](#input\_storage\_account\_trusted\_services\_enabled) | Enable trusted Microsoft services to bypass storage account network rules. | `bool` | `false` | no |
+| <a name="input_subnet_appservices_name"></a> [subnet\_appservices\_name](#input\_subnet\_appservices\_name) | Name of the subnet created for integrating the App Services | `string` | `"snet-scepman-appservices"` | no |
+| <a name="input_subnet_endpoints_name"></a> [subnet\_endpoints\_name](#input\_subnet\_endpoints\_name) | Name of the subnet created for the other endpoints | `string` | `"snet-scepman-endpoints"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
+| <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | Address-Space of the VNET | `list(any)` | <pre>[<br>  "10.158.200.0/24"<br>]</pre> | no |
+| <a name="input_vnet_name"></a> [vnet\_name](#input\_vnet\_name) | Name of the VNET created for internal communication | `string` | `"vnet-scepman"` | no |
 
 ## Outputs
 
-| Name                                                                                                                                 | Description                    |
-| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| Name | Description |
+|------|-------------|
 | <a name="output_scepman_certificate_master_url"></a> [scepman\_certificate\_master\_url](#output\_scepman\_certificate\_master\_url) | SCEPman Certificate Master Url |
-| <a name="output_scepman_url"></a> [scepman\_url](#output\_scepman\_url)                                                              | SCEPman Url                    |
+| <a name="output_scepman_url"></a> [scepman\_url](#output\_scepman\_url) | SCEPman Url |
+| <a name="output_storage_account_id"></a> [storage\_account\_id](#output\_storage\_account\_id) | ID of the storage account used by the deployment. |
+| <a name="output_storage_account_identity_principal_id"></a> [storage\_account\_identity\_principal\_id](#output\_storage\_account\_identity\_principal\_id) | Principal ID of the storage account system-assigned managed identity when enabled. |
+| <a name="output_storage_account_identity_tenant_id"></a> [storage\_account\_identity\_tenant\_id](#output\_storage\_account\_identity\_tenant\_id) | Tenant ID of the storage account system-assigned managed identity when enabled. |
 <!-- END_TF_DOCS -->

--- a/examples/advanced/README.md
+++ b/examples/advanced/README.md
@@ -17,6 +17,20 @@ Note: The following Azure Resource names must be globally unique:
 
 If you want to deploy the Community Edition, leave `AppConfig:LicenseKey` in `app_settings_primary` as *trial*. If you want to deploy the Enterprise Edition, use your valid license key.
 
+> **Azure AD authentication required**: Shared keys are disabled by default. Set `storage_use_azuread = true` (or export `ARM_STORAGE_USE_AZUREAD=true`) in your provider configuration and assign the deploying identity the `Storage Queue Data Contributor` and `Storage Table Data Contributor` roles on the storage account.
+
+### Storage hardening options
+
+The module now disables storage account public network access and shared key authentication by default. You can override the behavior through the following optional variables when needed:
+
+- `storage_account_public_network_access_enabled`
+- `storage_account_trusted_services_enabled`
+- `storage_account_min_tls_version`
+- `storage_account_sas_expiration_period`
+- `storage_account_blob_soft_delete_retention_days`
+- `storage_account_container_soft_delete_retention_days`
+- `storage_account_managed_identity_enabled`
+
 ### Deploy Configuration
 
 ```hcl

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -16,8 +16,9 @@ terraform {
 
 provider "azurerm" {
   features {}
-  partner_id      = "a262352f-52a9-4ed9-a9ba-6a2b2478d19b"
-  subscription_id = var.subscription_id
+  storage_use_azuread = true
+  partner_id          = "a262352f-52a9-4ed9-a9ba-6a2b2478d19b"
+  subscription_id     = var.subscription_id
 }
 
 # Resources
@@ -41,9 +42,10 @@ module "scepman" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = var.location
 
-  storage_account_name = var.storage_account_name
-  key_vault_name       = var.key_vault_name
-  law_name             = var.law_name
+  storage_account_name                     = var.storage_account_name
+  key_vault_name                           = var.key_vault_name
+  law_name                                 = var.law_name
+  storage_account_managed_identity_enabled = var.storage_account_managed_identity_enabled
 
   service_plan_os_type                = var.service_plan_os_type
   service_plan_name                   = var.service_plan_name

--- a/examples/advanced/terraform.tfvars
+++ b/examples/advanced/terraform.tfvars
@@ -2,7 +2,7 @@ subscription_id = "00000000-0000-0000-0000-000000000000"
 
 organization_name   = "my-org"
 location            = "westeurope"
-resource_group_name = "rg-scepman-dev-02520"
+resource_group_name = "rg-scepman-dev-025"
 
 storage_account_name                     = "stscepmandev025"
 key_vault_name                           = "kv-scepman-prod-025"

--- a/examples/advanced/terraform.tfvars
+++ b/examples/advanced/terraform.tfvars
@@ -1,16 +1,20 @@
-organization_name    = "my-org"
-location             = "westeurope"
-resource_group_name  = "rg-scepman-dev-025"
-storage_account_name = "stscepmandev025"
-key_vault_name       = "kv-scepman-prod-025"
-law_name             = "law-scepman-prod-025"
-subscription_id      = "00000000-0000-0000-0000-000000000000"
+subscription_id = "00000000-0000-0000-0000-000000000000"
 
-service_plan_os_type                = "Windows"
+organization_name   = "my-org"
+location            = "westeurope"
+resource_group_name = "rg-scepman-dev-02520"
+
+storage_account_name                     = "stscepmandev025"
+key_vault_name                           = "kv-scepman-prod-025"
+law_name                                 = "law-scepman-prod-025"
+storage_account_managed_identity_enabled = false
+
+service_plan_os_type                = "Linux"
 service_plan_name                   = "plan-scepman-prod-025"
-service_plan_sku                    = "s1"
+service_plan_sku                    = "B2"
 app_service_name_primary            = "app-scepman-dev-025"
 app_service_name_certificate_master = "app-scepmancm-dev-025"
+
 
 enable_application_insights = false
 

--- a/examples/advanced/variables.tf
+++ b/examples/advanced/variables.tf
@@ -24,6 +24,60 @@ variable "storage_account_name" {
   description = "Name of the storage account"
 }
 
+variable "storage_account_public_network_access_enabled" {
+  type        = bool
+  default     = false
+  description = "Allow public network access to the storage account."
+}
+
+variable "storage_account_trusted_services_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable trusted Microsoft services to bypass storage account network rules."
+}
+
+variable "storage_account_min_tls_version" {
+  type        = string
+  default     = "TLS1_2"
+  description = "Minimum TLS version for the storage account endpoint."
+}
+
+variable "storage_account_shared_access_key_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable shared access key authentication for the storage account. Default is false to enforce more secure authentication methods."
+}
+
+variable "storage_account_allow_nested_items_to_be_public" {
+  type        = bool
+  default     = false
+  description = "Allow nested items (containers) to inherit public access."
+}
+
+variable "storage_account_sas_expiration_period" {
+  type        = string
+  default     = "1.00:00:00"
+  description = "Expiration period applied to SAS tokens in d.hh:mm:ss format."
+}
+
+variable "storage_account_blob_soft_delete_retention_days" {
+  type        = number
+  default     = 7
+  description = "Retention in days for blob soft delete. Set to 0 to keep soft delete disabled."
+}
+
+variable "storage_account_container_soft_delete_retention_days" {
+  type        = number
+  default     = 7
+  description = "Retention in days for container soft delete. Set to 0 to keep soft delete disabled."
+}
+
+variable "storage_account_managed_identity_enabled" {
+  type        = bool
+  default     = false
+  description = "Assign a system managed identity to the storage account for Customer Managed Keys."
+}
+
 variable "law_name" {
   type        = string
   description = "Name for the Log Analytics Workspace"

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -4,6 +4,10 @@ SCEPman deployment with reasonable defaults to get you started quickly
 
 This example deploys the free Community Edition, but you can upgrade your existing SCEPman instance to an Enterprise Edition later by adding your [license key](https://docs.scepman.com/advanced-configuration/application-settings/basics#appconfig-licensekey).
 
+Public network access to the storage account is disabled by default. If you need to expose it temporarily or enable Trusted Microsoft Services, set the corresponding variables when instantiating the module.
+
+> **Azure AD authentication required**: Because shared keys are disabled, Terraform must talk to the storage account using Azure AD. Configure the provider with `storage_use_azuread = true` (or export `ARM_STORAGE_USE_AZUREAD=true`) and grant your deployment principal `Storage Queue Data Contributor` and `Storage Table Data Contributor` roles on the account.
+
 ## Using this example with Terraform CLI
 
 ### Variables

--- a/examples/quickstart/main.tf
+++ b/examples/quickstart/main.tf
@@ -16,8 +16,9 @@ terraform {
 
 provider "azurerm" {
   features {}
-  partner_id = "a262352f-52a9-4ed9-a9ba-6a2b2478d19b"
-  subscription_id = var.subscription_id
+  storage_use_azuread = true
+  partner_id          = "a262352f-52a9-4ed9-a9ba-6a2b2478d19b"
+  subscription_id     = var.subscription_id
 }
 
 # Resources
@@ -45,10 +46,10 @@ locals {
 
 module "scepman" {
   # Option 1: Local module, use from local development
-  source = "../.." # This is the local path to the module
+  # source = "../.." # This is the local path to the module
 
   # Option 2: Use the terraform registry version
-  #source = "scepman/scepman/azurerm"
+  source = "scepman/scepman/azurerm"
   # version = "0.1.0"
 
 

--- a/examples/quickstart/terraform.tfvars
+++ b/examples/quickstart/terraform.tfvars
@@ -1,1 +1,1 @@
-location             = "westeurope"
+location = "westeurope"

--- a/examples/quickstart/variables.tf
+++ b/examples/quickstart/variables.tf
@@ -6,7 +6,7 @@ variable "location" {
 variable "resource_group_name" {
   type        = string
   description = "Name of the resource group"
-  default = "rg-scepman-quickstart-001"
+  default     = "rg-scepman-quickstart-001"
 }
 
 variable "tags" {

--- a/keyvault.tf
+++ b/keyvault.tf
@@ -5,9 +5,9 @@ resource "azurerm_key_vault" "vault" {
   resource_group_name = var.resource_group_name
   location            = var.location
 
-  tenant_id                 = data.azurerm_client_config.current.tenant_id
-  sku_name                  = "premium"
-  enable_rbac_authorization = var.key_vault_use_rbac
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  rbac_authorization_enabled = var.key_vault_use_rbac
 
   enabled_for_disk_encryption     = false
   enabled_for_deployment          = false
@@ -32,7 +32,7 @@ locals {
 
 # Key Vault Access Policy
 resource "azurerm_key_vault_access_policy" "scepman" {
-  count = azurerm_key_vault.vault.enable_rbac_authorization ? 0 : 1
+  count = azurerm_key_vault.vault.rbac_authorization_enabled ? 0 : 1
 
   key_vault_id = azurerm_key_vault.vault.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
@@ -61,7 +61,7 @@ resource "azurerm_key_vault_access_policy" "scepman" {
 }
 
 resource "azurerm_role_assignment" "kv_roles" {
-  for_each = azurerm_key_vault.vault.enable_rbac_authorization ? local.key_vault_roles : {}
+  for_each = azurerm_key_vault.vault.rbac_authorization_enabled ? local.key_vault_roles : {}
 
   scope                = azurerm_key_vault.vault.id
   role_definition_name = each.key

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,18 @@ output "scepman_certificate_master_url" {
   value       = format("https://%s", var.service_plan_os_type == "Linux" ? azurerm_linux_web_app.app_cm[0].default_hostname : azurerm_windows_web_app.app_cm[0].default_hostname)
   description = "SCEPman Certificate Master Url"
 }
+
+output "storage_account_id" {
+  value       = azurerm_storage_account.storage.id
+  description = "ID of the storage account used by the deployment."
+}
+
+output "storage_account_identity_principal_id" {
+  value       = try(azurerm_storage_account.storage.identity[0].principal_id, null)
+  description = "Principal ID of the storage account system-assigned managed identity when enabled."
+}
+
+output "storage_account_identity_tenant_id" {
+  value       = try(azurerm_storage_account.storage.identity[0].tenant_id, null)
+  description = "Tenant ID of the storage account system-assigned managed identity when enabled."
+}

--- a/storageaccount.tf
+++ b/storageaccount.tf
@@ -5,17 +5,53 @@ resource "azurerm_storage_account" "storage" {
   resource_group_name = var.resource_group_name
   location            = var.location
 
-  public_network_access_enabled = true
+  public_network_access_enabled   = var.storage_account_public_network_access_enabled
+  min_tls_version                 = var.storage_account_min_tls_version
+  allow_nested_items_to_be_public = var.storage_account_allow_nested_items_to_be_public
+  shared_access_key_enabled       = var.storage_account_shared_access_key_enabled
 
   network_rules {
     default_action             = "Deny"
     ip_rules                   = []
     virtual_network_subnet_ids = []
-    bypass                     = ["None"]
+    bypass                     = var.storage_account_trusted_services_enabled ? ["AzureServices"] : ["None"]
   }
 
   account_tier             = "Standard"
   account_replication_type = var.storage_account_replication_type
+
+  dynamic "sas_policy" {
+    for_each = var.storage_account_sas_expiration_period != null ? [var.storage_account_sas_expiration_period] : []
+    content {
+      expiration_period = sas_policy.value
+    }
+  }
+
+  dynamic "blob_properties" {
+    for_each = var.storage_account_blob_soft_delete_retention_days > 0 || var.storage_account_container_soft_delete_retention_days > 0 ? [1] : []
+    content {
+      dynamic "delete_retention_policy" {
+        for_each = var.storage_account_blob_soft_delete_retention_days > 0 ? [var.storage_account_blob_soft_delete_retention_days] : []
+        content {
+          days = delete_retention_policy.value
+        }
+      }
+
+      dynamic "container_delete_retention_policy" {
+        for_each = var.storage_account_container_soft_delete_retention_days > 0 ? [var.storage_account_container_soft_delete_retention_days] : []
+        content {
+          days = container_delete_retention_policy.value
+        }
+      }
+    }
+  }
+
+  dynamic "identity" {
+    for_each = var.storage_account_managed_identity_enabled ? [1] : []
+    content {
+      type = "SystemAssigned"
+    }
+  }
 
   tags = var.tags
 }

--- a/storageaccount.tf
+++ b/storageaccount.tf
@@ -21,7 +21,7 @@ resource "azurerm_storage_account" "storage" {
   account_replication_type = var.storage_account_replication_type
 
   dynamic "sas_policy" {
-    for_each = var.storage_account_sas_expiration_period != null ? [var.storage_account_sas_expiration_period] : []
+    for_each = [var.storage_account_sas_expiration_period]
     content {
       expiration_period = sas_policy.value
     }

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,75 @@ variable "storage_account_replication_type" {
   }
 }
 
+variable "storage_account_public_network_access_enabled" {
+  type        = bool
+  default     = false
+  description = "Allow public network access to the storage account. Default disables external access to rely on private endpoints."
+}
+
+variable "storage_account_trusted_services_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable trusted Microsoft services to bypass storage account network rules."
+}
+
+variable "storage_account_allow_nested_items_to_be_public" {
+  type        = bool
+  default     = false
+  description = "Allow nested items (containers/directories) to inherit public access."
+}
+
+variable "storage_account_min_tls_version" {
+  type        = string
+  default     = "TLS1_2"
+  description = "Minimum TLS version for the storage account endpoint."
+
+  validation {
+    condition     = contains(["TLS1_0", "TLS1_1", "TLS1_2", "TLS1_3"], var.storage_account_min_tls_version)
+    error_message = "Storage account minimum TLS version must be one of: TLS1_0, TLS1_1, TLS1_2, TLS1_3."
+  }
+}
+
+variable "storage_account_shared_access_key_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable shared access key authentication for the storage account. Default is false to enforce more secure authentication methods."
+}
+
+variable "storage_account_sas_expiration_period" {
+  type        = string
+  default     = "1.00:00:00"
+  description = "Default expiration period applied to user delegation and service SAS tokens in d.hh:mm:ss format."
+}
+
+variable "storage_account_blob_soft_delete_retention_days" {
+  type        = number
+  default     = 7
+  description = "Retention in days for blob soft delete. Set to 0 to keep soft delete disabled."
+
+  validation {
+    condition     = var.storage_account_blob_soft_delete_retention_days >= 0 && var.storage_account_blob_soft_delete_retention_days <= 365
+    error_message = "Blob soft delete retention must be between 0 and 365 days."
+  }
+}
+
+variable "storage_account_container_soft_delete_retention_days" {
+  type        = number
+  default     = 7
+  description = "Retention in days for container soft delete. Set to 0 to keep soft delete disabled."
+
+  validation {
+    condition     = var.storage_account_container_soft_delete_retention_days >= 0 && var.storage_account_container_soft_delete_retention_days <= 365
+    error_message = "Container soft delete retention must be between 0 and 365 days."
+  }
+}
+
+variable "storage_account_managed_identity_enabled" {
+  type        = bool
+  default     = false
+  description = "Assign a system managed identity to the storage account to support Customer Managed Keys."
+}
+
 variable "law_name" {
   type        = string
   description = "Name for the Log Analytics Workspace"


### PR DESCRIPTION
- Disable public network access and shared key authentication for storage accounts by default.
- Introduce new variables for storage account configurations including public access, trusted services, and TLS version.
- Update examples to reflect changes in storage account settings and Azure AD authentication requirements.
- Revise README files to provide clearer instructions on security defaults and example usage.
- Enhance the advanced example with additional configurations for storage account management and identity.
- Update outputs to include storage account identity details.