### PR TITLE
rename deprecated `enable_rbac_authorization` attribute

### DIFF
--- a/keyvault.tf
+++ b/keyvault.tf
@@ -5,9 +5,9 @@ resource "azurerm_key_vault" "vault" {
   resource_group_name = var.resource_group_name
   location            = var.location
 
-  tenant_id                 = data.azurerm_client_config.current.tenant_id
-  sku_name                  = "premium"
-  enable_rbac_authorization = var.key_vault_use_rbac
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  rbac_authorization_enabled = var.key_vault_use_rbac
 
   enabled_for_disk_encryption     = false
   enabled_for_deployment          = false
@@ -32,7 +32,7 @@ locals {
 
 # Key Vault Access Policy
 resource "azurerm_key_vault_access_policy" "scepman" {
-  count = azurerm_key_vault.vault.enable_rbac_authorization ? 0 : 1
+  count = azurerm_key_vault.vault.rbac_authorization_enabled ? 0 : 1
 
   key_vault_id = azurerm_key_vault.vault.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
@@ -61,7 +61,7 @@ resource "azurerm_key_vault_access_policy" "scepman" {
 }
 
 resource "azurerm_role_assignment" "kv_roles" {
-  for_each = azurerm_key_vault.vault.enable_rbac_authorization ? local.key_vault_roles : {}
+  for_each = azurerm_key_vault.vault.rbac_authorization_enabled ? local.key_vault_roles : {}
 
   scope                = azurerm_key_vault.vault.id
   role_definition_name = each.key


### PR DESCRIPTION
Rename `enable_rbac_authorization ` to `rbac_authorization_enabled` due to deprecation.
```
╷
│ Warning: Argument is deprecated
│
│   with module.scepman.azurerm_key_vault.vault,
│   on .terraform\modules\scepman\keyvault.tf line 10, in resource "azurerm_key_vault" "vault":
│   10:   enable_rbac_authorization = var.key_vault_use_rbac
│
│ This property has been renamed to `rbac_authorization_enabled` and will be removed in v5.0 of the provider
╵
╷
│ Warning: Deprecated attribute
│
│   on .terraform\modules\scepman\keyvault.tf line 35, in resource "azurerm_key_vault_access_policy" "scepman":
│   35:   count = azurerm_key_vault.vault.enable_rbac_authorization ? 0 : 1
│
│ The attribute "enable_rbac_authorization" is deprecated. Refer to the provider documentation for details.
│
│ (and 3 more similar warnings elsewhere)
╵

```
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault#rbac_authorization_enabled-1