### PR TITLE
fix: avoid null error when law_cross_subscription_details is not set

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -129,7 +129,7 @@ variable "law_cross_subscription_details" {
     error_message = "When provided, law_cross_subscription_details.workspace_id must be a UUID."
   }
   validation {
-    condition     = var.law_cross_subscription_details == null || length(trimspace(var.law_cross_subscription_details.shared_key)) > 0
+    condition     = var.law_cross_subscription_details == null || length(trimspace(try(var.law_cross_subscription_details.shared_key, ""))) > 0
     error_message = "When provided, law_cross_subscription_details.shared_key must be non-empty."
   }
   validation {


### PR DESCRIPTION
This PR fixes a Terraform error that happened when
law_cross_subscription_details was null.

The old validation tried to read shared_key even when
the whole object was null. Now it uses try() so it no
longer crashes.

Fixes #32 