### PR TITLE
feat(dcr): implement Data Collection Rule and endpoint for SCEPman log ingestion

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -27,7 +27,6 @@ content: |-
     law_cross_subscription_details = {
       id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-monitoring/providers/Microsoft.OperationalInsights/workspaces/law-central"
       workspace_id = "00000000-0000-0000-0000-000000000000"
-      shared_key   = "redacted-primary-shared-key"
     }
   ```
   When you supply `law_cross_subscription_details`, omit both `law_name` and `law_resource_group_name`.

--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ To re-use an existing Log Analytics Workspace that lives in another subscription
   law_cross_subscription_details = {
     id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-monitoring/providers/Microsoft.OperationalInsights/workspaces/law-central"
     workspace_id = "00000000-0000-0000-0000-000000000000"
-    shared_key   = "redacted-primary-shared-key"
   }
 ```
 When you supply `law_cross_subscription_details`, omit both `law_name` and `law_resource_group_name`.
@@ -195,7 +194,7 @@ When you supply `law_cross_subscription_details`, omit both `law_name` and `law_
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_app_service_application_logs_file_system_level"></a> [app\_service\_application\_logs\_file\_system\_level](#input\_app\_service\_application\_logs\_file\_system\_level) | Application Log level for file\_system | `string` | `"Error"` | no |
 | <a name="input_app_service_logs_detailed_error_messages"></a> [app\_service\_logs\_detailed\_error\_messages](#input\_app\_service\_logs\_detailed\_error\_messages) | Detailed Error messages of the app service | `bool` | `true` | no |
 | <a name="input_app_service_logs_failed_request_tracing"></a> [app\_service\_logs\_failed\_request\_tracing](#input\_app\_service\_logs\_failed\_request\_tracing) | Trace failed requests | `bool` | `false` | no |
@@ -210,10 +209,13 @@ When you supply `law_cross_subscription_details`, omit both `law_name` and `law_
 | <a name="input_artifacts_url_certificate_master"></a> [artifacts\_url\_certificate\_master](#input\_artifacts\_url\_certificate\_master) | URL of the artifacts for SCEPman Certificate Master | `string` | `"https://raw.githubusercontent.com/scepman/install/master/dist-certmaster/CertMaster-Artifacts.zip"` | no |
 | <a name="input_artifacts_url_primary"></a> [artifacts\_url\_primary](#input\_artifacts\_url\_primary) | URL of the artifacts for SCEPman | `string` | `"https://raw.githubusercontent.com/scepman/install/master/dist/Artifacts.zip"` | no |
 | <a name="input_certificate_master_uami_ids"></a> [certificate\_master\_uami\_ids](#input\_certificate\_master\_uami\_ids) | Set of user assigned managed identity resource IDs to assign to the SCEPman Certificate Master app service. The certificate master app service will always have a system assigned managed identity. This setting therefore is optional and for advanced use cases where additional user assigned managed identities need to be assigned to the app service. For most use cases, this can be left empty. | `set(string)` | `[]` | no |
+| <a name="input_dce_name"></a> [dce\_name](#input\_dce\_name) | Name of the Data Collection Endpoint for SCEPman log ingestion. | `string` | `"dce-scepmanlogs"` | no |
+| <a name="input_dcr_name"></a> [dcr\_name](#input\_dcr\_name) | Name of the Data Collection Rule for SCEPman logs. | `string` | `"dcr-scepmanlogs"` | no |
 | <a name="input_enable_application_insights"></a> [enable\_application\_insights](#input\_enable\_application\_insights) | Should Terraform create and connect Application Insights for the App services? NOTE: This will prevent Terraform from beeing able to destroy the ressource group! | `bool` | `false` | no |
+| <a name="input_enable_dcr_log_ingestion"></a> [enable\_dcr\_log\_ingestion](#input\_enable\_dcr\_log\_ingestion) | Use the DCR-based Log Ingestion API instead of the deprecated Data Collector API (shared key). The Data Collector API is being retired — set to false only as a temporary opt-out during migration. | `bool` | `true` | no |
 | <a name="input_key_vault_name"></a> [key\_vault\_name](#input\_key\_vault\_name) | Name of the key vault | `string` | n/a | yes |
 | <a name="input_key_vault_use_rbac"></a> [key\_vault\_use\_rbac](#input\_key\_vault\_use\_rbac) | Use RBAC for the key vault or the older access policies | `bool` | `true` | no |
-| <a name="input_law_cross_subscription_details"></a> [law\_cross\_subscription\_details](#input\_law\_cross\_subscription\_details) | Used to reference an existing Log Analytics Workspace located in another subscription. Use this instead of law\_name and law\_resource\_group\_name. | <pre>object({<br/>    id           = string<br/>    workspace_id = string<br/>    shared_key   = string<br/>  })</pre> | `null` | no |
+| <a name="input_law_cross_subscription_details"></a> [law\_cross\_subscription\_details](#input\_law\_cross\_subscription\_details) | Used to reference an existing Log Analytics Workspace located in another subscription. Use this instead of law\_name and law\_resource\_group\_name. The shared\_key field is only required when enable\_dcr\_log\_ingestion is false (deprecated path). | <pre>object({<br/>    id           = string<br/>    workspace_id = string<br/>    shared_key   = optional(string, "")<br/>  })</pre> | `null` | no |
 | <a name="input_law_name"></a> [law\_name](#input\_law\_name) | Name for the Log Analytics Workspace | `string` | `null` | no |
 | <a name="input_law_resource_group_name"></a> [law\_resource\_group\_name](#input\_law\_resource\_group\_name) | Resource Group of existing Log Analytics Workspace | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | Azure Region where the resources should be created | `string` | n/a | yes |
@@ -247,10 +249,13 @@ When you supply `law_cross_subscription_details`, omit both `law_name` and `law_
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_app_services"></a> [app\_services](#output\_app\_services) | Information about the deployed App Services for SCEPman |
 | <a name="output_certmaster_application"></a> [certmaster\_application](#output\_certmaster\_application) | Information about the Application and Service Principal for the SCEPman Certificate Master |
 | <a name="output_certmaster_mi_principal_id"></a> [certmaster\_mi\_principal\_id](#output\_certmaster\_mi\_principal\_id) | principal\_id of the system assigned managed identity of the SCEPman certificate master |
+| <a name="output_dce_id"></a> [dce\_id](#output\_dce\_id) | Resource ID of the Data Collection Endpoint for SCEPman log ingestion. Null when enable\_dcr\_log\_ingestion is false. |
+| <a name="output_dcr_id"></a> [dcr\_id](#output\_dcr\_id) | Resource ID of the Data Collection Rule for SCEPman logs. Null when enable\_dcr\_log\_ingestion is false. |
+| <a name="output_dcr_immutable_id"></a> [dcr\_immutable\_id](#output\_dcr\_immutable\_id) | Immutable ID of the Data Collection Rule. Null when enable\_dcr\_log\_ingestion is false. |
 | <a name="output_primary_mi_principal_id"></a> [primary\_mi\_principal\_id](#output\_primary\_mi\_principal\_id) | principal\_id of the system assigned managed identity of the SCEPman primary app |
 | <a name="output_scepman_application"></a> [scepman\_application](#output\_scepman\_application) | Information about the Application and Service Principal for the SCEPman API |
 | <a name="output_scepman_certificate_master_url"></a> [scepman\_certificate\_master\_url](#output\_scepman\_certificate\_master\_url) | SCEPman Certificate Master Url |

--- a/dcr.tf
+++ b/dcr.tf
@@ -1,0 +1,198 @@
+# Data Collection Rule (DCR) based log ingestion
+# Replaces the deprecated Data Collector API (shared key based)
+
+resource "azurerm_monitor_data_collection_endpoint" "scepman" {
+  count = var.enable_dcr_log_ingestion ? 1 : 0
+
+  name                = var.dce_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  tags = var.tags
+}
+
+resource "azurerm_log_analytics_workspace_table_custom_log" "scepman" {
+  count = var.enable_dcr_log_ingestion ? 1 : 0
+
+  workspace_id = local.law_id
+  name         = "SCEPman_CL"
+
+  column {
+    name = "TimeGenerated"
+    type = "datetime"
+  }
+  column {
+    name = "Timestamp"
+    type = "string"
+  }
+  column {
+    name = "Level"
+    type = "string"
+  }
+  column {
+    name = "Message"
+    type = "string"
+  }
+  column {
+    name = "Exception"
+    type = "string"
+  }
+  column {
+    name = "TenantIdentifier"
+    type = "string"
+  }
+  column {
+    name = "RequestUrl"
+    type = "string"
+  }
+  column {
+    name = "UserAgent"
+    type = "string"
+  }
+  column {
+    name = "LogCategory"
+    type = "string"
+  }
+  column {
+    name = "EventId"
+    type = "string"
+  }
+  column {
+    name = "Hostname"
+    type = "string"
+  }
+  column {
+    name = "WebsiteHostname"
+    type = "string"
+  }
+  column {
+    name = "WebsiteSiteName"
+    type = "string"
+  }
+  column {
+    name = "WebsiteSlotName"
+    type = "string"
+  }
+  column {
+    name = "BaseUrl"
+    type = "string"
+  }
+  column {
+    name = "TraceIdentifier"
+    type = "string"
+  }
+}
+
+resource "azurerm_monitor_data_collection_rule" "scepman" {
+  count = var.enable_dcr_log_ingestion ? 1 : 0
+
+  name                        = var.dcr_name
+  resource_group_name         = var.resource_group_name
+  location                    = var.location
+  data_collection_endpoint_id = azurerm_monitor_data_collection_endpoint.scepman[0].id
+  kind                        = "Direct"
+  description                 = "Data Collection Rule for SCEPman logs"
+
+  destinations {
+    log_analytics {
+      workspace_resource_id = local.law_id
+      name                  = "SCEPmanLogAnalyticsDestination"
+    }
+  }
+
+  stream_declaration {
+    stream_name = "Custom-SCEPmanLogs"
+
+    column {
+      name = "TimeGenerated"
+      type = "datetime"
+    }
+    column {
+      name = "Timestamp"
+      type = "string"
+    }
+    column {
+      name = "Level"
+      type = "string"
+    }
+    column {
+      name = "Message"
+      type = "string"
+    }
+    column {
+      name = "Exception"
+      type = "string"
+    }
+    column {
+      name = "TenantIdentifier"
+      type = "string"
+    }
+    column {
+      name = "RequestUrl"
+      type = "string"
+    }
+    column {
+      name = "UserAgent"
+      type = "string"
+    }
+    column {
+      name = "LogCategory"
+      type = "string"
+    }
+    column {
+      name = "EventId"
+      type = "string"
+    }
+    column {
+      name = "Hostname"
+      type = "string"
+    }
+    column {
+      name = "WebsiteHostname"
+      type = "string"
+    }
+    column {
+      name = "WebsiteSiteName"
+      type = "string"
+    }
+    column {
+      name = "WebsiteSlotName"
+      type = "string"
+    }
+    column {
+      name = "BaseUrl"
+      type = "string"
+    }
+    column {
+      name = "TraceIdentifier"
+      type = "string"
+    }
+  }
+
+  data_flow {
+    streams       = ["Custom-SCEPmanLogs"]
+    destinations  = ["SCEPmanLogAnalyticsDestination"]
+    output_stream = "Custom-SCEPman_CL"
+  }
+
+  depends_on = [azurerm_log_analytics_workspace_table_custom_log.scepman]
+
+  tags = var.tags
+}
+
+# Role assignments: Monitoring Metrics Publisher on the DCR for both app service managed identities
+resource "azurerm_role_assignment" "scepman_primary_dcr_metrics_publisher" {
+  count = var.enable_dcr_log_ingestion ? 1 : 0
+
+  scope                = azurerm_monitor_data_collection_rule.scepman[0].id
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = local.scepman_mi_principal_id
+}
+
+resource "azurerm_role_assignment" "scepman_certmaster_dcr_metrics_publisher" {
+  count = var.enable_dcr_log_ingestion ? 1 : 0
+
+  scope                = azurerm_monitor_data_collection_rule.scepman[0].id
+  role_definition_name = "Monitoring Metrics Publisher"
+  principal_id         = local.cm_mi_principal_id
+}

--- a/locals.tf
+++ b/locals.tf
@@ -113,13 +113,21 @@ locals {
     "AppConfig:KeyVaultConfig:KeyVaultURL"              = azurerm_key_vault.vault.vault_uri
     "AppConfig:CertificateStorage:TableStorageEndpoint" = azurerm_storage_account.storage.primary_table_endpoint
     "AppConfig:LoggingConfig:WorkspaceId"               = local.law_workspace_id
-    "AppConfig:LoggingConfig:SharedKey"                 = local.law_shared_key
+  }
+
+  app_settings_primary_dcr = var.enable_dcr_log_ingestion ? {
+    "AppConfig:LoggingConfig:DataCollectionEndpointUri" = azurerm_monitor_data_collection_endpoint.scepman[0].logs_ingestion_endpoint
+    "AppConfig:LoggingConfig:RuleId"                    = azurerm_monitor_data_collection_rule.scepman[0].immutable_id
+  } : {}
+
+  app_settings_primary_legacy_log = var.enable_dcr_log_ingestion ? {} : {
+    "AppConfig:LoggingConfig:SharedKey" = local.law_shared_key
   }
 
   // Normalize input app settings to use ":" as separator for easier merging
   normalized_app_settings_primary = { for k, v in var.app_settings_primary : replace(k, "__", ":") => v }
   // Merge maps will overwrite first by last > default variables, custom variables, resource variables
-  merged_app_settings_primary = merge(local.app_settings_primary_defaults, local.normalized_app_settings_primary, local.app_settings_primary_app_insights, local.app_settings_primary_base, local.app_settings_primary_app)
+  merged_app_settings_primary = merge(local.app_settings_primary_defaults, local.normalized_app_settings_primary, local.app_settings_primary_app_insights, local.app_settings_primary_base, local.app_settings_primary_dcr, local.app_settings_primary_legacy_log, local.app_settings_primary_app)
   // If OS is linux, replace ":" with"__" in app settings, if OS is windows (NOT linux), replace "__" with ":" in app settings
   app_settings_primary = lower(var.service_plan_os_type) == "linux" ? { for k, v in local.merged_app_settings_primary : replace(k, ":", "__") => v } : { for k, v in local.merged_app_settings_primary : replace(k, "__", ":") => v }
 
@@ -166,7 +174,15 @@ locals {
     "AppConfig:SCEPman:URL"                       = local.app_settings_primary_url
     "AppConfig:AuthConfig:TenantId"               = data.azurerm_client_config.current.tenant_id
     "AppConfig:LoggingConfig:WorkspaceId"         = local.law_workspace_id
-    "AppConfig:LoggingConfig:SharedKey"           = local.law_shared_key
+  }
+
+  app_settings_certificate_master_dcr = var.enable_dcr_log_ingestion ? {
+    "AppConfig:LoggingConfig:DataCollectionEndpointUri" = azurerm_monitor_data_collection_endpoint.scepman[0].logs_ingestion_endpoint
+    "AppConfig:LoggingConfig:RuleId"                    = azurerm_monitor_data_collection_rule.scepman[0].immutable_id
+  } : {}
+
+  app_settings_certificate_master_legacy_log = var.enable_dcr_log_ingestion ? {} : {
+    "AppConfig:LoggingConfig:SharedKey" = local.law_shared_key
   }
 
   app_settings_certificate_master_app = var.manage_entra_apps ? {
@@ -187,7 +203,7 @@ locals {
   // Normalize input app settings to use ":" as separator for easier merging
   normalized_app_settings_certificate_master = { for k, v in var.app_settings_certificate_master : replace(k, "__", ":") => v }
   // Merge maps will overwrite first by last > default variables, custom variables, resource variables
-  merged_app_settings_certificate_master = merge(local.app_settings_certificate_master_defaults, local.normalized_app_settings_certificate_master, local.app_settings_certificate_master_app_insights, local.app_settings_certificate_master_base, local.app_settings_certificate_master_app)
+  merged_app_settings_certificate_master = merge(local.app_settings_certificate_master_defaults, local.normalized_app_settings_certificate_master, local.app_settings_certificate_master_app_insights, local.app_settings_certificate_master_base, local.app_settings_certificate_master_dcr, local.app_settings_certificate_master_legacy_log, local.app_settings_certificate_master_app)
   // If OS is linux, replace ":" with"__" in app settings, if OS is windows (NOT linux), replace "__" with ":" in app settings
   app_settings_certificate_master = lower(var.service_plan_os_type) == "linux" ? { for k, v in local.merged_app_settings_certificate_master : replace(k, ":", "__") => v } : { for k, v in local.merged_app_settings_certificate_master : replace(k, "__", ":") => v }
 

--- a/main.tf
+++ b/main.tf
@@ -46,14 +46,18 @@ resource "azurerm_log_analytics_workspace" "law" {
 
 locals {
   # Prioritize workspace details from cross-subscription input, then data lookup, and finally the workspace created by this module.
-  law_details = var.law_cross_subscription_details != null ? var.law_cross_subscription_details : length(data.azurerm_log_analytics_workspace.existing-law) > 0 ? {
+  law_details = var.law_cross_subscription_details != null ? {
+    id           = var.law_cross_subscription_details.id
+    workspace_id = var.law_cross_subscription_details.workspace_id
+    shared_key   = var.law_cross_subscription_details.shared_key
+    } : length(data.azurerm_log_analytics_workspace.existing-law) > 0 ? {
     id           = data.azurerm_log_analytics_workspace.existing-law[0].id
     workspace_id = data.azurerm_log_analytics_workspace.existing-law[0].workspace_id
-    shared_key   = data.azurerm_log_analytics_workspace.existing-law[0].primary_shared_key
+    shared_key   = var.enable_dcr_log_ingestion ? "" : data.azurerm_log_analytics_workspace.existing-law[0].primary_shared_key
     } : {
     id           = azurerm_log_analytics_workspace.law[0].id
     workspace_id = azurerm_log_analytics_workspace.law[0].workspace_id
-    shared_key   = azurerm_log_analytics_workspace.law[0].primary_shared_key
+    shared_key   = var.enable_dcr_log_ingestion ? "" : azurerm_log_analytics_workspace.law[0].primary_shared_key
   }
 
   law_id           = local.law_details.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -99,3 +99,18 @@ output "certmaster_mi_principal_id" {
   value       = local.cm_mi_principal_id
   description = "principal_id of the system assigned managed identity of the SCEPman certificate master"
 }
+
+output "dcr_id" {
+  value       = try(azurerm_monitor_data_collection_rule.scepman[0].id, null)
+  description = "Resource ID of the Data Collection Rule for SCEPman logs. Null when enable_dcr_log_ingestion is false."
+}
+
+output "dce_id" {
+  value       = try(azurerm_monitor_data_collection_endpoint.scepman[0].id, null)
+  description = "Resource ID of the Data Collection Endpoint for SCEPman log ingestion. Null when enable_dcr_log_ingestion is false."
+}
+
+output "dcr_immutable_id" {
+  value       = try(azurerm_monitor_data_collection_rule.scepman[0].immutable_id, null)
+  description = "Immutable ID of the Data Collection Rule. Null when enable_dcr_log_ingestion is false."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -115,11 +115,11 @@ variable "law_cross_subscription_details" {
   type = object({
     id           = string
     workspace_id = string
-    shared_key   = string
+    shared_key   = optional(string, "")
   })
   default     = null
   nullable    = true
-  description = "Used to reference an existing Log Analytics Workspace located in another subscription. Use this instead of law_name and law_resource_group_name."
+  description = "Used to reference an existing Log Analytics Workspace located in another subscription. Use this instead of law_name and law_resource_group_name. The shared_key field is only required when enable_dcr_log_ingestion is false (deprecated path)."
   validation {
     condition     = var.law_cross_subscription_details == null || can(regex("^/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/resourceGroups/[^/]+/providers/Microsoft\\.OperationalInsights/workspaces/[^/]+$", var.law_cross_subscription_details.id))
     error_message = "When provided, law_cross_subscription_details.id must be a valid Log Analytics workspace resource ID."
@@ -129,8 +129,8 @@ variable "law_cross_subscription_details" {
     error_message = "When provided, law_cross_subscription_details.workspace_id must be a UUID."
   }
   validation {
-    condition     = var.law_cross_subscription_details == null || length(trimspace(try(var.law_cross_subscription_details.shared_key, ""))) > 0
-    error_message = "When provided, law_cross_subscription_details.shared_key must be non-empty."
+    condition     = var.law_cross_subscription_details == null || var.enable_dcr_log_ingestion || length(trimspace(coalesce(var.law_cross_subscription_details.shared_key, ""))) > 0
+    error_message = "When provided and enable_dcr_log_ingestion is false, law_cross_subscription_details.shared_key must be non-empty."
   }
   validation {
     condition     = var.law_cross_subscription_details == null || (var.law_name == null && var.law_resource_group_name == null)
@@ -329,4 +329,22 @@ variable "certificate_master_uami_ids" {
   type        = set(string)
   description = "Set of user assigned managed identity resource IDs to assign to the SCEPman Certificate Master app service. The certificate master app service will always have a system assigned managed identity. This setting therefore is optional and for advanced use cases where additional user assigned managed identities need to be assigned to the app service. For most use cases, this can be left empty."
   default     = []
+}
+
+variable "enable_dcr_log_ingestion" {
+  type        = bool
+  default     = true
+  description = "Use the DCR-based Log Ingestion API instead of the deprecated Data Collector API (shared key). The Data Collector API is being retired — set to false only as a temporary opt-out during migration."
+}
+
+variable "dcr_name" {
+  type        = string
+  default     = "dcr-scepmanlogs"
+  description = "Name of the Data Collection Rule for SCEPman logs."
+}
+
+variable "dce_name" {
+  type        = string
+  default     = "dce-scepmanlogs"
+  description = "Name of the Data Collection Endpoint for SCEPman log ingestion."
 }


### PR DESCRIPTION
This pull request introduces a major update to support Azure's new Data Collection Rule (DCR)–based log ingestion for SCEPman, replacing the deprecated Data Collector API (shared key). The changes are backward compatible, allowing migration by toggling the new `enable_dcr_log_ingestion` variable. Documentation, variables, outputs, and logic have all been updated to support both the new and legacy log ingestion paths.

The most important changes are:

**DCR-based Log Ingestion Implementation**
* Added `dcr.tf` to provision a Data Collection Endpoint and Data Collection Rule, custom log table, and role assignments for managed identities when `enable_dcr_log_ingestion` is true. This enables the new, recommended log ingestion path.
* Application settings for both SCEPman primary and certificate master apps are now dynamically configured to use DCR endpoint and rule IDs when enabled, or the legacy shared key otherwise. [[1]](diffhunk://#diff-9a576c4980b4f226b7ef1042670d564777bbb0ed8ae2d1df33afbd03e2991fcdR116-R130) [[2]](diffhunk://#diff-9a576c4980b4f226b7ef1042670d564777bbb0ed8ae2d1df33afbd03e2991fcdR177-R184) [[3]](diffhunk://#diff-9a576c4980b4f226b7ef1042670d564777bbb0ed8ae2d1df33afbd03e2991fcdL190-R206)

**Variable and Input Updates**
* Introduced new variables: `enable_dcr_log_ingestion`, `dcr_name`, and `dce_name` (with defaults), and updated the `law_cross_subscription_details` variable to make `shared_key` optional and only required for the legacy path. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR333-R350) [[2]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL118-R122)
* Updated validation logic for `law_cross_subscription_details` to enforce `shared_key` only when the legacy ingestion is used.

**Documentation Improvements**
* Updated `README.md` and `.terraform-docs.yml` to document the new variables, outputs, and migration guidance for DCR-based ingestion. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R212-R218) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L190-R197) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L250-R258) [[4]](diffhunk://#diff-1870602938553c78bf18176e356ff2e25b50db7bdae4b6421f0b1b6bdd5a026dL30)

**Output Enhancements**
* Added outputs for the DCR and DCE resource IDs and the immutable DCR ID, to aid in integration and validation.

**Logic and Compatibility**
* Refactored workspace selection and shared key logic in `main.tf` to ensure the shared key is only required and populated for the legacy ingestion path.

The new behaviour is the default, as the legacy log-ingestion method is being deprecated by Microsoft in September 2026. Reverting to the old behaviour is possible as opt-out by setting the `enable_dcr_log_ingestion` to `false`, but not recommended.