### PR TITLE
feat: Add configurable network access restrictions for App Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ network_access_restrictions_primary = {
 }
 ```
 
-**VNet-only access (private deployment):**
+**Deny-by-default with VNet allowlist:**
 ```hcl
 network_access_restrictions_primary = {
   public_network_access_enabled     = true

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Each variable accepts an object with the following attributes:
 | `scm_ip_restriction_default_action` | `string` | Default action for SCM/Kudu endpoint when no rule matches (`"Allow"` or `"Deny"`). |
 | `scm_ip_restrictions` | `list(object)` | List of SCM/Kudu endpoint IP restriction rules (same schema as `ip_restrictions`). |
 
+> **Note:** Each rule requires `priority` (unique integer) and exactly one of `ip_address`, `service_tag`, or `virtual_network_subnet_id`.
+
+> **⚠️ Certificate Master → Primary connectivity:** Restricting the primary App Service can break Certificate Master, which reaches SCEPman via the primary's public hostname. If you lock down the primary, ensure Certificate Master's egress is allowed (e.g., via VNet route-all + subnet allow rule, or an explicit IP allow rule).
+
 ### Enterprise Use Case Examples
 
 **Deny-by-default with corporate VPN access:**
@@ -266,6 +270,36 @@ module "scepman" {
   enable_application_insights = var.enable_application_insights
   manage_entra_apps           = true
 
+  # Optional: Configure network access restrictions for the primary SCEPman app
+  # network_access_restrictions_primary = {
+  #   public_network_access_enabled = true
+  #   ip_restriction_default_action = "Deny"
+  #   ip_restrictions = [
+  #     {
+  #       name       = "allow-corp-vpn"
+  #       priority   = 100
+  #       action     = "Allow"
+  #       ip_address = "203.0.113.0/24"
+  #     }
+  #   ]
+  #   scm_ip_restriction_default_action = "Deny"
+  #   scm_ip_restrictions = [
+  #     {
+  #       name        = "allow-build-agents"
+  #       priority    = 100
+  #       action      = "Allow"
+  #       service_tag = "AzureDevOps"
+  #     }
+  #   ]
+  # }
+
+  # Optional: Configure network access restrictions for Certificate Master
+  # network_access_restrictions_certificate_master = {
+  #   public_network_access_enabled     = false
+  #   ip_restriction_default_action     = "Deny"
+  #   scm_ip_restriction_default_action = "Deny"
+  # }
+
   tags = var.tags
 }
 ```
@@ -320,7 +354,7 @@ When `subnet_appservices_address_prefix` or `subnet_endpoints_address_prefix` ar
 
 For enterprise environments with centrally managed networking (e.g., using [Azure Verified Module for Virtual Networks](https://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork)), you can pass existing subnet IDs instead of letting the module create its own networking resources.
 
-Set `create_networking = false` and provide `existing_subnet_appservices_id`.
+Set `create_networking = false` and provide `existing_subnet_appservices_id`. The explicit boolean toggle ensures plan-time determinism — subnet IDs may be unknown until apply (e.g., when the networking module runs in the same plan) without causing Terraform `count` errors. A `check` block enforces at apply time that `existing_subnet_appservices_id` is provided and is a valid Azure subnet resource ID.
 
 When `create_networking` is `false`, the module skips creation of: VNet, subnets, NSGs, Private DNS zones, Private DNS zone links, and Private Endpoints. You are responsible for managing these externally, including:
 - Subnet delegation (`Microsoft.Web/serverFarms`) on the App Services subnet
@@ -365,7 +399,7 @@ module "scepman" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_app_service_application_logs_file_system_level"></a> [app\_service\_application\_logs\_file\_system\_level](#input\_app\_service\_application\_logs\_file\_system\_level) | Application Log level for file\_system | `string` | `"Error"` | no |
 | <a name="input_app_service_logs_detailed_error_messages"></a> [app\_service\_logs\_detailed\_error\_messages](#input\_app\_service\_logs\_detailed\_error\_messages) | Detailed Error messages of the app service | `bool` | `true` | no |
 | <a name="input_app_service_logs_failed_request_tracing"></a> [app\_service\_logs\_failed\_request\_tracing](#input\_app\_service\_logs\_failed\_request\_tracing) | Trace failed requests | `bool` | `false` | no |
@@ -380,7 +414,7 @@ module "scepman" {
 | <a name="input_artifacts_url_certificate_master"></a> [artifacts\_url\_certificate\_master](#input\_artifacts\_url\_certificate\_master) | URL of the artifacts for SCEPman Certificate Master | `string` | `"https://raw.githubusercontent.com/scepman/install/master/dist-certmaster/CertMaster-Artifacts.zip"` | no |
 | <a name="input_artifacts_url_primary"></a> [artifacts\_url\_primary](#input\_artifacts\_url\_primary) | URL of the artifacts for SCEPman | `string` | `"https://raw.githubusercontent.com/scepman/install/master/dist/Artifacts.zip"` | no |
 | <a name="input_certificate_master_uami_ids"></a> [certificate\_master\_uami\_ids](#input\_certificate\_master\_uami\_ids) | Set of user assigned managed identity resource IDs to assign to the SCEPman Certificate Master app service. The certificate master app service will always have a system assigned managed identity. This setting therefore is optional and for advanced use cases where additional user assigned managed identities need to be assigned to the app service. For most use cases, this can be left empty. | `set(string)` | `[]` | no |
-| <a name="input_create_networking"></a> [create\_networking](#input\_create\_networking) | Whether the module should create and manage networking resources (VNet, subnets, NSGs, Private DNS zones, DNS zone links, Private Endpoints). Set to false to use pre-existing subnets (BYOS); in this mode, you must provide existing\_subnet\_appservices\_id. You are responsible for managing Private Endpoints, DNS zones, and NSGs externally. This explicit toggle ensures plan-time determinism even when subnet IDs are computed from other modules in the same plan. | `bool` | `true` | no |
+| <a name="input_create_networking"></a> [create\_networking](#input\_create\_networking) | Whether the module creates networking resources (VNet, subnets, NSGs, DNS zones, Private Endpoints). Set to false for BYOS mode — provide existing\_subnet\_appservices\_id and manage networking externally. | `bool` | `true` | no |
 | <a name="input_enable_application_insights"></a> [enable\_application\_insights](#input\_enable\_application\_insights) | Should Terraform create and connect Application Insights for the App services? NOTE: This will prevent Terraform from beeing able to destroy the ressource group! | `bool` | `false` | no |
 | <a name="input_existing_subnet_appservices_id"></a> [existing\_subnet\_appservices\_id](#input\_existing\_subnet\_appservices\_id) | Resource ID of an existing subnet delegated to Microsoft.Web/serverFarms for App Service VNet integration. Required when create\_networking is false; presence and format are validated at apply time via a check block to support computed values from other modules in the same plan. | `string` | `null` | no |
 | <a name="input_key_vault_name"></a> [key\_vault\_name](#input\_key\_vault\_name) | Name of the key vault | `string` | n/a | yes |
@@ -390,6 +424,8 @@ module "scepman" {
 | <a name="input_law_resource_group_name"></a> [law\_resource\_group\_name](#input\_law\_resource\_group\_name) | Resource Group of existing Log Analytics Workspace | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | Azure Region where the resources should be created | `string` | n/a | yes |
 | <a name="input_manage_entra_apps"></a> [manage\_entra\_apps](#input\_manage\_entra\_apps) | Whether to manage the Entra app registrations for SCEPman and Certificate Master within this module. If set to true, the user executing this must have Global Administrator privileges in the tenant/the service principal must have Application.ReadWrite.All, AppRoleAssignment.ReadWrite.All, DelegatedPermissionGrant.ReadWrite.All permissions. For legacy installations, which were created before this setting existed, only set to true if you wish to migrate to the new model. For new installations, it is recommended to set this to true. | `bool` | `false` | no |
+| <a name="input_network_access_restrictions_certificate_master"></a> [network\_access\_restrictions\_certificate\_master](#input\_network\_access\_restrictions\_certificate\_master) | Network access restrictions for the Certificate Master App Service. Controls public network access, inbound IP restrictions, and SCM/Kudu endpoint restrictions. When null (default), no restrictions are applied and the existing behavior is preserved. | <pre>object({<br/>    public_network_access_enabled = optional(bool)<br/>    ip_restriction_default_action = optional(string)<br/>    ip_restrictions = optional(list(object({<br/>      action = optional(string, "Allow")<br/>      headers = optional(object({<br/>        x_azure_fdid      = optional(set(string))<br/>        x_fd_health_probe = optional(set(string))<br/>        x_forwarded_for   = optional(set(string))<br/>        x_forwarded_host  = optional(set(string))<br/>      }))<br/>      ip_address                = optional(string)<br/>      name                      = optional(string)<br/>      priority                  = optional(number)<br/>      service_tag               = optional(string)<br/>      virtual_network_subnet_id = optional(string)<br/>    })))<br/>    scm_ip_restriction_default_action = optional(string)<br/>    scm_ip_restrictions = optional(list(object({<br/>      action = optional(string, "Allow")<br/>      headers = optional(object({<br/>        x_azure_fdid      = optional(set(string))<br/>        x_fd_health_probe = optional(set(string))<br/>        x_forwarded_for   = optional(set(string))<br/>        x_forwarded_host  = optional(set(string))<br/>      }))<br/>      ip_address                = optional(string)<br/>      name                      = optional(string)<br/>      priority                  = optional(number)<br/>      service_tag               = optional(string)<br/>      virtual_network_subnet_id = optional(string)<br/>    })))<br/>  })</pre> | `null` | no |
+| <a name="input_network_access_restrictions_primary"></a> [network\_access\_restrictions\_primary](#input\_network\_access\_restrictions\_primary) | Network access restrictions for the SCEPman primary App Service. Controls public network access, inbound IP restrictions, and SCM/Kudu endpoint restrictions. When null (default), no restrictions are applied and the existing behavior is preserved. | <pre>object({<br/>    public_network_access_enabled = optional(bool)<br/>    ip_restriction_default_action = optional(string)<br/>    ip_restrictions = optional(list(object({<br/>      action = optional(string, "Allow")<br/>      headers = optional(object({<br/>        x_azure_fdid      = optional(set(string))<br/>        x_fd_health_probe = optional(set(string))<br/>        x_forwarded_for   = optional(set(string))<br/>        x_forwarded_host  = optional(set(string))<br/>      }))<br/>      ip_address                = optional(string)<br/>      name                      = optional(string)<br/>      priority                  = optional(number)<br/>      service_tag               = optional(string)<br/>      virtual_network_subnet_id = optional(string)<br/>    })))<br/>    scm_ip_restriction_default_action = optional(string)<br/>    scm_ip_restrictions = optional(list(object({<br/>      action = optional(string, "Allow")<br/>      headers = optional(object({<br/>        x_azure_fdid      = optional(set(string))<br/>        x_fd_health_probe = optional(set(string))<br/>        x_forwarded_for   = optional(set(string))<br/>        x_forwarded_host  = optional(set(string))<br/>      }))<br/>      ip_address                = optional(string)<br/>      name                      = optional(string)<br/>      priority                  = optional(number)<br/>      service_tag               = optional(string)<br/>      virtual_network_subnet_id = optional(string)<br/>    })))<br/>  })</pre> | `null` | no |
 | <a name="input_nsg_appservices_name"></a> [nsg\_appservices\_name](#input\_nsg\_appservices\_name) | Name of the Network Security Group for the app services subnet. Ignored when create\_networking is false. | `string` | `"nsg-scepman-appservices"` | no |
 | <a name="input_nsg_endpoints_name"></a> [nsg\_endpoints\_name](#input\_nsg\_endpoints\_name) | Name of the Network Security Group for the endpoints subnet. Ignored when create\_networking is false. | `string` | `"nsg-scepman-endpoints"` | no |
 | <a name="input_organization_name"></a> [organization\_name](#input\_organization\_name) | Organization name (O=<my-org>) | `string` | `"my-org"` | no |
@@ -410,9 +446,9 @@ module "scepman" {
 | <a name="input_storage_account_sas_expiration_period"></a> [storage\_account\_sas\_expiration\_period](#input\_storage\_account\_sas\_expiration\_period) | Default expiration period applied to user delegation and service SAS tokens in d.hh:mm:ss format. | `string` | `"1.00:00:00"` | no |
 | <a name="input_storage_account_shared_access_key_enabled"></a> [storage\_account\_shared\_access\_key\_enabled](#input\_storage\_account\_shared\_access\_key\_enabled) | Enable shared access key authentication for the storage account. Default is false to enforce more secure authentication methods. | `bool` | `false` | no |
 | <a name="input_storage_account_trusted_services_enabled"></a> [storage\_account\_trusted\_services\_enabled](#input\_storage\_account\_trusted\_services\_enabled) | Enable trusted Microsoft services to bypass storage account network rules. | `bool` | `false` | no |
-| <a name="input_subnet_appservices_address_prefix"></a> [subnet\_appservices\_address\_prefix](#input\_subnet\_appservices\_address\_prefix) | CIDR address prefix for the App Services subnet (e.g., from IPAM). When null, the prefix is auto-calculated from vnet\_address\_space using cidrsubnet(). Ignored when create\_networking is false. | `string` | `null` | no |
+| <a name="input_subnet_appservices_address_prefix"></a> [subnet\_appservices\_address\_prefix](#input\_subnet\_appservices\_address\_prefix) | CIDR address prefix for the App Services subnet (e.g., from IPAM). When null, the prefix is auto-calculated from vnet\_address\_space using cidrsubnet(). Ignored when create\_networking is false. Note: Azure validates at apply time that the prefix is within the VNet address space and does not overlap other subnets. | `string` | `null` | no |
 | <a name="input_subnet_appservices_name"></a> [subnet\_appservices\_name](#input\_subnet\_appservices\_name) | Name of the subnet created for integrating the App Services. Ignored when create\_networking is false. | `string` | `"snet-scepman-appservices"` | no |
-| <a name="input_subnet_endpoints_address_prefix"></a> [subnet\_endpoints\_address\_prefix](#input\_subnet\_endpoints\_address\_prefix) | CIDR address prefix for the Private Endpoints subnet (e.g., from IPAM). When null, the prefix is auto-calculated from vnet\_address\_space using cidrsubnet(). Ignored when create\_networking is false. | `string` | `null` | no |
+| <a name="input_subnet_endpoints_address_prefix"></a> [subnet\_endpoints\_address\_prefix](#input\_subnet\_endpoints\_address\_prefix) | CIDR address prefix for the Private Endpoints subnet (e.g., from IPAM). When null, the prefix is auto-calculated from vnet\_address\_space using cidrsubnet(). Ignored when create\_networking is false. Note: Azure validates at apply time that the prefix is within the VNet address space and does not overlap other subnets. | `string` | `null` | no |
 | <a name="input_subnet_endpoints_name"></a> [subnet\_endpoints\_name](#input\_subnet\_endpoints\_name) | Name of the subnet created for the other endpoints. Ignored when create\_networking is false. | `string` | `"snet-scepman-endpoints"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resource | `map(string)` | `{}` | no |
 | <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | Address-Space of the VNET. Ignored when create\_networking is false. | `list(any)` | <pre>[<br/>  "10.158.200.0/24"<br/>]</pre> | no |
@@ -421,7 +457,7 @@ module "scepman" {
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_app_services"></a> [app\_services](#output\_app\_services) | Information about the deployed App Services for SCEPman |
 | <a name="output_certmaster_application"></a> [certmaster\_application](#output\_certmaster\_application) | Information about the Application and Service Principal for the SCEPman Certificate Master |
 | <a name="output_certmaster_mi_principal_id"></a> [certmaster\_mi\_principal\_id](#output\_certmaster\_mi\_principal\_id) | principal\_id of the system assigned managed identity of the SCEPman certificate master |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,94 @@ Visit [containers.dev](https://containers.dev) for more information
 - Optional inputs allow enabling trusted Microsoft services or soft-delete retention when required.
 - Because shared keys are disabled, Terraform must use Azure AD for all storage data plane operations. Set `storage_use_azuread = true` in your provider configuration (or export `ARM_STORAGE_USE_AZUREAD=true`) and assign your deployment principal the roles `Storage Queue Data Contributor` and `Storage Table Data Contributor` on the storage account.
 
+## Network Access Restrictions
+
+Both App Services (SCEPman primary and Certificate Master) support configurable network access restrictions via the `network_access_restrictions_primary` and `network_access_restrictions_certificate_master` variables.
+
+By default, these variables are `null`, which preserves the existing permissive behavior and ensures zero diff for existing deployments.
+
+### Configuration Options
+
+Each variable accepts an object with the following attributes:
+
+| Attribute | Type | Description |
+|---|---|---|
+| `public_network_access_enabled` | `bool` | Enable or disable public network access to the App Service. Set to `false` for private-only deployments. |
+| `ip_restriction_default_action` | `string` | Default action when no IP restriction rule matches (`"Allow"` or `"Deny"`). Set to `"Deny"` for deny-by-default. |
+| `ip_restrictions` | `list(object)` | List of inbound IP restriction rules. Each rule supports `action`, `ip_address`, `service_tag`, `virtual_network_subnet_id`, `name`, `priority`, and `headers`. |
+| `scm_ip_restriction_default_action` | `string` | Default action for SCM/Kudu endpoint when no rule matches (`"Allow"` or `"Deny"`). |
+| `scm_ip_restrictions` | `list(object)` | List of SCM/Kudu endpoint IP restriction rules (same schema as `ip_restrictions`). |
+
+### Enterprise Use Case Examples
+
+**Deny-by-default with corporate VPN access:**
+```hcl
+network_access_restrictions_primary = {
+  public_network_access_enabled     = true
+  ip_restriction_default_action     = "Deny"
+  scm_ip_restriction_default_action = "Deny"
+  ip_restrictions = [
+    {
+      name       = "corp-vpn"
+      priority   = 100
+      action     = "Allow"
+      ip_address = "203.0.113.0/24"
+    }
+  ]
+  scm_ip_restrictions = [
+    {
+      name        = "azure-devops"
+      priority    = 100
+      action      = "Allow"
+      service_tag = "AzureDevOps"
+    }
+  ]
+}
+```
+
+**VNet-only access (private deployment):**
+```hcl
+network_access_restrictions_primary = {
+  public_network_access_enabled     = true
+  ip_restriction_default_action     = "Deny"
+  scm_ip_restriction_default_action = "Deny"
+  ip_restrictions = [
+    {
+      name                      = "internal-vnet"
+      priority                  = 100
+      action                    = "Allow"
+      virtual_network_subnet_id = "/subscriptions/.../subnets/app-subnet"
+    }
+  ]
+}
+```
+
+**Behind Azure Front Door:**
+```hcl
+network_access_restrictions_primary = {
+  ip_restriction_default_action     = "Deny"
+  scm_ip_restriction_default_action = "Deny"
+  ip_restrictions = [
+    {
+      name        = "azure-front-door"
+      priority    = 100
+      action      = "Allow"
+      service_tag = "AzureFrontDoor.Backend"
+      headers = {
+        x_azure_fdid = ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
+      }
+    }
+  ]
+}
+```
+
+**Fully private (no public access):**
+```hcl
+network_access_restrictions_certificate_master = {
+  public_network_access_enabled = false
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Visit [containers.dev](https://containers.dev) for more information
 
 Both App Services (SCEPman primary and Certificate Master) support configurable network access restrictions via the `network_access_restrictions_primary` and `network_access_restrictions_certificate_master` variables.
 
-By default, these variables are `null`, which preserves the existing permissive behavior and ensures zero diff for existing deployments.
+By default, these variables are `null`, which preserves the existing permissive behavior and should not require infrastructure changes for existing deployments.
 
 ### Configuration Options
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -60,10 +60,15 @@ module "scepman" {
 - Adding restrictions will modify the App Service `site_config` in-place (no recreation).
 - Setting `public_network_access_enabled = false` will immediately block all public traffic.
   Ensure private endpoints or VNet integration is configured before disabling public access.
-- **Certificate Master → Primary connectivity:** The Certificate Master communicates with the
-  primary App Service via its public hostname. If you restrict or disable public access on the
-  primary, ensure the Certificate Master's outbound traffic is allowed (e.g., by enabling
-  `vnet_route_all_enabled` and adding the integrated subnet to the primary's allow list, or by
-  using a private endpoint). Otherwise, Certificate Master requests to the primary will fail.
+- Restricting the **primary** App Service can break **Certificate Master** communication, because
+  Certificate Master reaches SCEPman via the primary's public hostname (`local.default_hostname_primary`,
+  used in `AppConfig:SCEPman:URL`).
+- If you set `public_network_access_enabled = false` on the primary, or configure a deny-by-default
+  `ip_restrictions` policy, make sure the Certificate Master's egress is still allowed to reach the
+  primary. By default, Certificate Master uses the standard outbound Azure IPs, not the integrated
+  subnet, unless `vnet_route_all_enabled` / `WEBSITE_VNET_ROUTE_ALL` is enabled.
+- When locking down the primary, allow Certificate Master's egress either by routing all traffic
+  through the integrated VNet subnet with route-all enabled, or by adding an explicit allow rule for
+  the actual outbound source that reaches the primary.
 - IP restriction rules are evaluated by priority (lowest number = highest priority).
 - Use `service_tag` for Azure service-level access (e.g., `AzureDevOps`, `AzureFrontDoor.Backend`).

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,11 +12,11 @@ for the SCEPman primary and Certificate Master App Services:
 
 ### Impact on Existing Deployments
 
-**None.** Both variables default to `null`, which means:
+**None to infrastructure behavior by default.** Both variables default to `null`, which means:
 
 - No `ip_restriction` or `scm_ip_restriction` blocks are rendered
-- `public_network_access_enabled` is not set (provider default applies)
-- Existing deployments will see **zero diff** on `terraform plan`
+- `public_network_access_enabled`, `ip_restriction_default_action`, and `scm_ip_restriction_default_action` continue to use provider/default behavior when unset
+- Existing deployments should not require infrastructure changes, but `terraform plan` may show an in-place or no-op `site_config` update depending on the current state and `azurerm` provider behavior
 - No resource recreation is triggered
 
 ### Migration Steps

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -60,5 +60,10 @@ module "scepman" {
 - Adding restrictions will modify the App Service `site_config` in-place (no recreation).
 - Setting `public_network_access_enabled = false` will immediately block all public traffic.
   Ensure private endpoints or VNet integration is configured before disabling public access.
+- **Certificate Master → Primary connectivity:** The Certificate Master communicates with the
+  primary App Service via its public hostname. If you restrict or disable public access on the
+  primary, ensure the Certificate Master's outbound traffic is allowed (e.g., by enabling
+  `vnet_route_all_enabled` and adding the integrated subnet to the primary's allow list, or by
+  using a private endpoint). Otherwise, Certificate Master requests to the primary will fail.
 - IP restriction rules are evaluated by priority (lowest number = highest priority).
 - Use `service_tag` for Azure service-level access (e.g., `AzureDevOps`, `AzureFrontDoor.Backend`).

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,64 @@
+# Upgrade Guide
+
+## Network Access Restrictions (New Feature)
+
+### What Changed
+
+Two new optional variables have been added to support configurable network access restrictions
+for the SCEPman primary and Certificate Master App Services:
+
+- `network_access_restrictions_primary`
+- `network_access_restrictions_certificate_master`
+
+### Impact on Existing Deployments
+
+**None.** Both variables default to `null`, which means:
+
+- No `ip_restriction` or `scm_ip_restriction` blocks are rendered
+- `public_network_access_enabled` is not set (provider default applies)
+- Existing deployments will see **zero diff** on `terraform plan`
+- No resource recreation is triggered
+
+### Migration Steps
+
+1. **Upgrade the module version** — no code changes required for existing behavior.
+2. **Optionally configure restrictions** — add the new variables to your module call when ready.
+
+### Example: Adding Restrictions to an Existing Deployment
+
+Before (no restrictions):
+```hcl
+module "scepman" {
+  source = "scepman/scepman/azurerm"
+  # ... existing configuration ...
+}
+```
+
+After (with deny-by-default):
+```hcl
+module "scepman" {
+  source = "scepman/scepman/azurerm"
+  # ... existing configuration ...
+
+  network_access_restrictions_primary = {
+    ip_restriction_default_action     = "Deny"
+    scm_ip_restriction_default_action = "Deny"
+    ip_restrictions = [
+      {
+        name       = "allow-corp"
+        priority   = 100
+        action     = "Allow"
+        ip_address = "10.0.0.0/8"
+      }
+    ]
+  }
+}
+```
+
+### Notes
+
+- Adding restrictions will modify the App Service `site_config` in-place (no recreation).
+- Setting `public_network_access_enabled = false` will immediately block all public traffic.
+  Ensure private endpoints or VNet integration is configured before disabling public access.
+- IP restriction rules are evaluated by priority (lowest number = highest priority).
+- Use `service_tag` for Azure service-level access (e.g., `AzureDevOps`, `AzureFrontDoor.Backend`).

--- a/appservices.full.tf
+++ b/appservices.full.tf
@@ -2,12 +2,13 @@
 # Scepman Primary
 
 resource "azurerm_windows_web_app" "app_full" {
-  count                     = (lower(var.service_plan_os_type) == "windows" && var.manage_entra_apps) ? 1 : 0
-  name                      = var.app_service_name_primary
-  resource_group_name       = var.resource_group_name
-  location                  = var.location
-  https_only                = false
-  virtual_network_subnet_id = local.subnet_appservices_id
+  count                         = (lower(var.service_plan_os_type) == "windows" && var.manage_entra_apps) ? 1 : 0
+  name                          = var.app_service_name_primary
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  https_only                    = false
+  virtual_network_subnet_id     = local.subnet_appservices_id
+  public_network_access_enabled = local.network_restrictions_primary != null ? local.network_restrictions_primary.public_network_access_enabled : null
 
   service_plan_id = local.service_plan_resource_id
 
@@ -24,6 +25,53 @@ resource "azurerm_windows_web_app" "app_full" {
     application_stack {
       current_stack  = "dotnet"
       dotnet_version = "v8.0"
+    }
+
+    ip_restriction_default_action     = local.network_restrictions_primary != null ? local.network_restrictions_primary.ip_restriction_default_action : null
+    scm_ip_restriction_default_action = local.network_restrictions_primary != null ? local.network_restrictions_primary.scm_ip_restriction_default_action : null
+
+    dynamic "ip_restriction" {
+      for_each = local.network_restrictions_primary != null ? local.network_restrictions_primary.ip_restrictions : []
+      content {
+        action                    = ip_restriction.value.action
+        ip_address                = ip_restriction.value.ip_address
+        name                      = ip_restriction.value.name
+        priority                  = ip_restriction.value.priority
+        service_tag               = ip_restriction.value.service_tag
+        virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = ip_restriction.value.headers != null ? [ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
+    }
+
+    dynamic "scm_ip_restriction" {
+      for_each = local.network_restrictions_primary != null ? local.network_restrictions_primary.scm_ip_restrictions : []
+      content {
+        action                    = scm_ip_restriction.value.action
+        ip_address                = scm_ip_restriction.value.ip_address
+        name                      = scm_ip_restriction.value.name
+        priority                  = scm_ip_restriction.value.priority
+        service_tag               = scm_ip_restriction.value.service_tag
+        virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = scm_ip_restriction.value.headers != null ? [scm_ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
     }
   }
 
@@ -64,12 +112,13 @@ resource "azurerm_windows_web_app" "app_full" {
 
 # Certificate Master App Service
 resource "azurerm_windows_web_app" "app_cm_full" {
-  count                     = (lower(var.service_plan_os_type) == "windows" && var.manage_entra_apps) ? 1 : 0
-  name                      = var.app_service_name_certificate_master
-  resource_group_name       = var.resource_group_name
-  location                  = var.location
-  https_only                = true
-  virtual_network_subnet_id = local.subnet_appservices_id
+  count                         = (lower(var.service_plan_os_type) == "windows" && var.manage_entra_apps) ? 1 : 0
+  name                          = var.app_service_name_certificate_master
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  https_only                    = true
+  virtual_network_subnet_id     = local.subnet_appservices_id
+  public_network_access_enabled = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.public_network_access_enabled : null
 
   service_plan_id = local.service_plan_resource_id
 
@@ -86,6 +135,53 @@ resource "azurerm_windows_web_app" "app_cm_full" {
     application_stack {
       current_stack  = "dotnet"
       dotnet_version = "v8.0"
+    }
+
+    ip_restriction_default_action     = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.ip_restriction_default_action : null
+    scm_ip_restriction_default_action = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.scm_ip_restriction_default_action : null
+
+    dynamic "ip_restriction" {
+      for_each = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.ip_restrictions : []
+      content {
+        action                    = ip_restriction.value.action
+        ip_address                = ip_restriction.value.ip_address
+        name                      = ip_restriction.value.name
+        priority                  = ip_restriction.value.priority
+        service_tag               = ip_restriction.value.service_tag
+        virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = ip_restriction.value.headers != null ? [ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
+    }
+
+    dynamic "scm_ip_restriction" {
+      for_each = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.scm_ip_restrictions : []
+      content {
+        action                    = scm_ip_restriction.value.action
+        ip_address                = scm_ip_restriction.value.ip_address
+        name                      = scm_ip_restriction.value.name
+        priority                  = scm_ip_restriction.value.priority
+        service_tag               = scm_ip_restriction.value.service_tag
+        virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = scm_ip_restriction.value.headers != null ? [scm_ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
     }
   }
 
@@ -122,12 +218,13 @@ resource "azurerm_windows_web_app" "app_cm_full" {
 ### Linux App Service
 # Scepman Primary
 resource "azurerm_linux_web_app" "app_full" {
-  count                     = (lower(var.service_plan_os_type) == "linux" && var.manage_entra_apps) ? 1 : 0
-  name                      = var.app_service_name_primary
-  resource_group_name       = var.resource_group_name
-  location                  = var.location
-  https_only                = false
-  virtual_network_subnet_id = local.subnet_appservices_id
+  count                         = (lower(var.service_plan_os_type) == "linux" && var.manage_entra_apps) ? 1 : 0
+  name                          = var.app_service_name_primary
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  https_only                    = false
+  virtual_network_subnet_id     = local.subnet_appservices_id
+  public_network_access_enabled = local.network_restrictions_primary != null ? local.network_restrictions_primary.public_network_access_enabled : null
 
   service_plan_id = local.service_plan_resource_id
 
@@ -144,6 +241,53 @@ resource "azurerm_linux_web_app" "app_full" {
     application_stack {
       #current_stack  = "dotnet"
       dotnet_version = "8.0"
+    }
+
+    ip_restriction_default_action     = local.network_restrictions_primary != null ? local.network_restrictions_primary.ip_restriction_default_action : null
+    scm_ip_restriction_default_action = local.network_restrictions_primary != null ? local.network_restrictions_primary.scm_ip_restriction_default_action : null
+
+    dynamic "ip_restriction" {
+      for_each = local.network_restrictions_primary != null ? local.network_restrictions_primary.ip_restrictions : []
+      content {
+        action                    = ip_restriction.value.action
+        ip_address                = ip_restriction.value.ip_address
+        name                      = ip_restriction.value.name
+        priority                  = ip_restriction.value.priority
+        service_tag               = ip_restriction.value.service_tag
+        virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = ip_restriction.value.headers != null ? [ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
+    }
+
+    dynamic "scm_ip_restriction" {
+      for_each = local.network_restrictions_primary != null ? local.network_restrictions_primary.scm_ip_restrictions : []
+      content {
+        action                    = scm_ip_restriction.value.action
+        ip_address                = scm_ip_restriction.value.ip_address
+        name                      = scm_ip_restriction.value.name
+        priority                  = scm_ip_restriction.value.priority
+        service_tag               = scm_ip_restriction.value.service_tag
+        virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = scm_ip_restriction.value.headers != null ? [scm_ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
     }
   }
 
@@ -185,12 +329,13 @@ resource "azurerm_linux_web_app" "app_full" {
 
 # Certificate Master App Service
 resource "azurerm_linux_web_app" "app_cm_full" {
-  count                     = (lower(var.service_plan_os_type) == "linux" && var.manage_entra_apps) ? 1 : 0
-  name                      = var.app_service_name_certificate_master
-  resource_group_name       = var.resource_group_name
-  location                  = var.location
-  https_only                = true
-  virtual_network_subnet_id = local.subnet_appservices_id
+  count                         = (lower(var.service_plan_os_type) == "linux" && var.manage_entra_apps) ? 1 : 0
+  name                          = var.app_service_name_certificate_master
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  https_only                    = true
+  virtual_network_subnet_id     = local.subnet_appservices_id
+  public_network_access_enabled = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.public_network_access_enabled : null
 
   service_plan_id = local.service_plan_resource_id
 
@@ -207,6 +352,53 @@ resource "azurerm_linux_web_app" "app_cm_full" {
     application_stack {
       #  current_stack  = "dotnet"
       dotnet_version = "8.0"
+    }
+
+    ip_restriction_default_action     = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.ip_restriction_default_action : null
+    scm_ip_restriction_default_action = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.scm_ip_restriction_default_action : null
+
+    dynamic "ip_restriction" {
+      for_each = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.ip_restrictions : []
+      content {
+        action                    = ip_restriction.value.action
+        ip_address                = ip_restriction.value.ip_address
+        name                      = ip_restriction.value.name
+        priority                  = ip_restriction.value.priority
+        service_tag               = ip_restriction.value.service_tag
+        virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = ip_restriction.value.headers != null ? [ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
+    }
+
+    dynamic "scm_ip_restriction" {
+      for_each = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.scm_ip_restrictions : []
+      content {
+        action                    = scm_ip_restriction.value.action
+        ip_address                = scm_ip_restriction.value.ip_address
+        name                      = scm_ip_restriction.value.name
+        priority                  = scm_ip_restriction.value.priority
+        service_tag               = scm_ip_restriction.value.service_tag
+        virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = scm_ip_restriction.value.headers != null ? [scm_ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
     }
   }
 

--- a/appservices.tf
+++ b/appservices.tf
@@ -7,12 +7,13 @@ resource "time_offset" "managed_identity" {
 ### Windows App Service
 # Scepman Primary
 resource "azurerm_windows_web_app" "app" {
-  count                     = (lower(var.service_plan_os_type) == "windows" && !var.manage_entra_apps) ? 1 : 0
-  name                      = var.app_service_name_primary
-  resource_group_name       = var.resource_group_name
-  location                  = var.location
-  https_only                = false
-  virtual_network_subnet_id = local.subnet_appservices_id
+  count                         = (lower(var.service_plan_os_type) == "windows" && !var.manage_entra_apps) ? 1 : 0
+  name                          = var.app_service_name_primary
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  https_only                    = false
+  virtual_network_subnet_id     = local.subnet_appservices_id
+  public_network_access_enabled = local.network_restrictions_primary != null ? local.network_restrictions_primary.public_network_access_enabled : null
 
   service_plan_id = local.service_plan_resource_id
 
@@ -29,6 +30,53 @@ resource "azurerm_windows_web_app" "app" {
     application_stack {
       current_stack  = "dotnet"
       dotnet_version = "v8.0"
+    }
+
+    ip_restriction_default_action     = local.network_restrictions_primary != null ? local.network_restrictions_primary.ip_restriction_default_action : null
+    scm_ip_restriction_default_action = local.network_restrictions_primary != null ? local.network_restrictions_primary.scm_ip_restriction_default_action : null
+
+    dynamic "ip_restriction" {
+      for_each = local.network_restrictions_primary != null ? local.network_restrictions_primary.ip_restrictions : []
+      content {
+        action                    = ip_restriction.value.action
+        ip_address                = ip_restriction.value.ip_address
+        name                      = ip_restriction.value.name
+        priority                  = ip_restriction.value.priority
+        service_tag               = ip_restriction.value.service_tag
+        virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = ip_restriction.value.headers != null ? [ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
+    }
+
+    dynamic "scm_ip_restriction" {
+      for_each = local.network_restrictions_primary != null ? local.network_restrictions_primary.scm_ip_restrictions : []
+      content {
+        action                    = scm_ip_restriction.value.action
+        ip_address                = scm_ip_restriction.value.ip_address
+        name                      = scm_ip_restriction.value.name
+        priority                  = scm_ip_restriction.value.priority
+        service_tag               = scm_ip_restriction.value.service_tag
+        virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = scm_ip_restriction.value.headers != null ? [scm_ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
     }
   }
 
@@ -74,12 +122,13 @@ resource "azurerm_windows_web_app" "app" {
 
 # Certificate Master App Service
 resource "azurerm_windows_web_app" "app_cm" {
-  count                     = (lower(var.service_plan_os_type) == "windows" && !var.manage_entra_apps) ? 1 : 0
-  name                      = var.app_service_name_certificate_master
-  resource_group_name       = var.resource_group_name
-  location                  = var.location
-  https_only                = true
-  virtual_network_subnet_id = local.subnet_appservices_id
+  count                         = (lower(var.service_plan_os_type) == "windows" && !var.manage_entra_apps) ? 1 : 0
+  name                          = var.app_service_name_certificate_master
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  https_only                    = true
+  virtual_network_subnet_id     = local.subnet_appservices_id
+  public_network_access_enabled = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.public_network_access_enabled : null
 
   service_plan_id = local.service_plan_resource_id
 
@@ -96,6 +145,53 @@ resource "azurerm_windows_web_app" "app_cm" {
     application_stack {
       current_stack  = "dotnet"
       dotnet_version = "v8.0"
+    }
+
+    ip_restriction_default_action     = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.ip_restriction_default_action : null
+    scm_ip_restriction_default_action = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.scm_ip_restriction_default_action : null
+
+    dynamic "ip_restriction" {
+      for_each = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.ip_restrictions : []
+      content {
+        action                    = ip_restriction.value.action
+        ip_address                = ip_restriction.value.ip_address
+        name                      = ip_restriction.value.name
+        priority                  = ip_restriction.value.priority
+        service_tag               = ip_restriction.value.service_tag
+        virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = ip_restriction.value.headers != null ? [ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
+    }
+
+    dynamic "scm_ip_restriction" {
+      for_each = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.scm_ip_restrictions : []
+      content {
+        action                    = scm_ip_restriction.value.action
+        ip_address                = scm_ip_restriction.value.ip_address
+        name                      = scm_ip_restriction.value.name
+        priority                  = scm_ip_restriction.value.priority
+        service_tag               = scm_ip_restriction.value.service_tag
+        virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = scm_ip_restriction.value.headers != null ? [scm_ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
     }
   }
 
@@ -139,12 +235,13 @@ resource "azurerm_windows_web_app" "app_cm" {
 ### Linux App Service
 # Scepman Primary
 resource "azurerm_linux_web_app" "app" {
-  count                     = lower(var.service_plan_os_type) == "linux" && !var.manage_entra_apps ? 1 : 0
-  name                      = var.app_service_name_primary
-  resource_group_name       = var.resource_group_name
-  location                  = var.location
-  https_only                = false
-  virtual_network_subnet_id = local.subnet_appservices_id
+  count                         = lower(var.service_plan_os_type) == "linux" && !var.manage_entra_apps ? 1 : 0
+  name                          = var.app_service_name_primary
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  https_only                    = false
+  virtual_network_subnet_id     = local.subnet_appservices_id
+  public_network_access_enabled = local.network_restrictions_primary != null ? local.network_restrictions_primary.public_network_access_enabled : null
 
   service_plan_id = local.service_plan_resource_id
 
@@ -161,6 +258,53 @@ resource "azurerm_linux_web_app" "app" {
     application_stack {
       #current_stack  = "dotnet"
       dotnet_version = "8.0"
+    }
+
+    ip_restriction_default_action     = local.network_restrictions_primary != null ? local.network_restrictions_primary.ip_restriction_default_action : null
+    scm_ip_restriction_default_action = local.network_restrictions_primary != null ? local.network_restrictions_primary.scm_ip_restriction_default_action : null
+
+    dynamic "ip_restriction" {
+      for_each = local.network_restrictions_primary != null ? local.network_restrictions_primary.ip_restrictions : []
+      content {
+        action                    = ip_restriction.value.action
+        ip_address                = ip_restriction.value.ip_address
+        name                      = ip_restriction.value.name
+        priority                  = ip_restriction.value.priority
+        service_tag               = ip_restriction.value.service_tag
+        virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = ip_restriction.value.headers != null ? [ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
+    }
+
+    dynamic "scm_ip_restriction" {
+      for_each = local.network_restrictions_primary != null ? local.network_restrictions_primary.scm_ip_restrictions : []
+      content {
+        action                    = scm_ip_restriction.value.action
+        ip_address                = scm_ip_restriction.value.ip_address
+        name                      = scm_ip_restriction.value.name
+        priority                  = scm_ip_restriction.value.priority
+        service_tag               = scm_ip_restriction.value.service_tag
+        virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = scm_ip_restriction.value.headers != null ? [scm_ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
     }
   }
 
@@ -207,12 +351,13 @@ resource "azurerm_linux_web_app" "app" {
 
 # Certificate Master App Service
 resource "azurerm_linux_web_app" "app_cm" {
-  count                     = (lower(var.service_plan_os_type) == "linux" && !var.manage_entra_apps) ? 1 : 0
-  name                      = var.app_service_name_certificate_master
-  resource_group_name       = var.resource_group_name
-  location                  = var.location
-  https_only                = true
-  virtual_network_subnet_id = local.subnet_appservices_id
+  count                         = (lower(var.service_plan_os_type) == "linux" && !var.manage_entra_apps) ? 1 : 0
+  name                          = var.app_service_name_certificate_master
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  https_only                    = true
+  virtual_network_subnet_id     = local.subnet_appservices_id
+  public_network_access_enabled = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.public_network_access_enabled : null
 
   service_plan_id = local.service_plan_resource_id
 
@@ -229,6 +374,53 @@ resource "azurerm_linux_web_app" "app_cm" {
     application_stack {
       #  current_stack  = "dotnet"
       dotnet_version = "8.0"
+    }
+
+    ip_restriction_default_action     = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.ip_restriction_default_action : null
+    scm_ip_restriction_default_action = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.scm_ip_restriction_default_action : null
+
+    dynamic "ip_restriction" {
+      for_each = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.ip_restrictions : []
+      content {
+        action                    = ip_restriction.value.action
+        ip_address                = ip_restriction.value.ip_address
+        name                      = ip_restriction.value.name
+        priority                  = ip_restriction.value.priority
+        service_tag               = ip_restriction.value.service_tag
+        virtual_network_subnet_id = ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = ip_restriction.value.headers != null ? [ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
+    }
+
+    dynamic "scm_ip_restriction" {
+      for_each = local.network_restrictions_certificate_master != null ? local.network_restrictions_certificate_master.scm_ip_restrictions : []
+      content {
+        action                    = scm_ip_restriction.value.action
+        ip_address                = scm_ip_restriction.value.ip_address
+        name                      = scm_ip_restriction.value.name
+        priority                  = scm_ip_restriction.value.priority
+        service_tag               = scm_ip_restriction.value.service_tag
+        virtual_network_subnet_id = scm_ip_restriction.value.virtual_network_subnet_id
+
+        dynamic "headers" {
+          for_each = scm_ip_restriction.value.headers != null ? [scm_ip_restriction.value.headers] : []
+          content {
+            x_azure_fdid      = headers.value.x_azure_fdid
+            x_fd_health_probe = headers.value.x_fd_health_probe
+            x_forwarded_for   = headers.value.x_forwarded_for
+            x_forwarded_host  = headers.value.x_forwarded_host
+          }
+        }
+      }
     }
   }
 

--- a/examples/advanced/main.tf
+++ b/examples/advanced/main.tf
@@ -58,5 +58,35 @@ module "scepman" {
   enable_application_insights = var.enable_application_insights
   manage_entra_apps           = true
 
+  # Optional: Configure network access restrictions for the primary SCEPman app
+  # network_access_restrictions_primary = {
+  #   public_network_access_enabled = true
+  #   ip_restriction_default_action = "Deny"
+  #   ip_restrictions = [
+  #     {
+  #       name       = "allow-corp-vpn"
+  #       priority   = 100
+  #       action     = "Allow"
+  #       ip_address = "203.0.113.0/24"
+  #     }
+  #   ]
+  #   scm_ip_restriction_default_action = "Deny"
+  #   scm_ip_restrictions = [
+  #     {
+  #       name        = "allow-build-agents"
+  #       priority    = 100
+  #       action      = "Allow"
+  #       service_tag = "AzureDevOps"
+  #     }
+  #   ]
+  # }
+
+  # Optional: Configure network access restrictions for Certificate Master
+  # network_access_restrictions_certificate_master = {
+  #   public_network_access_enabled     = false
+  #   ip_restriction_default_action     = "Deny"
+  #   scm_ip_restriction_default_action = "Deny"
+  # }
+
   tags = var.tags
 }

--- a/locals.tf
+++ b/locals.tf
@@ -175,6 +175,7 @@ locals {
     scm_ip_restrictions               = coalesce(var.network_access_restrictions_certificate_master.scm_ip_restrictions, [])
   } : null
 }
+
 # Certificate Master Locals
 locals {
 

--- a/locals.tf
+++ b/locals.tf
@@ -156,6 +156,25 @@ locals {
     identity_ids = length(var.primary_uami_ids) == 0 ? null : var.primary_uami_ids
   }
 }
+
+# Network access restriction locals
+locals {
+  network_restrictions_primary = var.network_access_restrictions_primary != null ? {
+    public_network_access_enabled     = var.network_access_restrictions_primary.public_network_access_enabled
+    ip_restriction_default_action     = var.network_access_restrictions_primary.ip_restriction_default_action
+    ip_restrictions                   = coalesce(var.network_access_restrictions_primary.ip_restrictions, [])
+    scm_ip_restriction_default_action = var.network_access_restrictions_primary.scm_ip_restriction_default_action
+    scm_ip_restrictions               = coalesce(var.network_access_restrictions_primary.scm_ip_restrictions, [])
+  } : null
+
+  network_restrictions_certificate_master = var.network_access_restrictions_certificate_master != null ? {
+    public_network_access_enabled     = var.network_access_restrictions_certificate_master.public_network_access_enabled
+    ip_restriction_default_action     = var.network_access_restrictions_certificate_master.ip_restriction_default_action
+    ip_restrictions                   = coalesce(var.network_access_restrictions_certificate_master.ip_restrictions, [])
+    scm_ip_restriction_default_action = var.network_access_restrictions_certificate_master.scm_ip_restriction_default_action
+    scm_ip_restrictions               = coalesce(var.network_access_restrictions_certificate_master.scm_ip_restrictions, [])
+  } : null
+}
 # Certificate Master Locals
 locals {
 

--- a/variables.tf
+++ b/variables.tf
@@ -278,10 +278,10 @@ variable "vnet_address_space" {
   default     = ["10.158.200.0/24"]
   description = "Address-Space of the VNET. Ignored when create_networking is false."
 
-    validation {
-      condition = length(var.vnet_address_space) > 0 && can(cidrhost(var.vnet_address_space[0], 0))
-      error_message = "vnet_address_space must be a list with at least one valid CIDR notation (e.g., [\"10.0.0.0/16\"])."
-    }
+  validation {
+    condition     = length(var.vnet_address_space) > 0 && can(cidrhost(var.vnet_address_space[0], 0))
+    error_message = "vnet_address_space must be a list with at least one valid CIDR notation (e.g., [\"10.0.0.0/16\"])."
+  }
 }
 
 variable "subnet_appservices_name" {
@@ -417,6 +417,22 @@ variable "network_access_restrictions_primary" {
     )
     error_message = "ip_restriction_default_action and scm_ip_restriction_default_action must be either 'Allow' or 'Deny'."
   }
+
+  validation {
+    condition = var.network_access_restrictions_primary == null || alltrue([
+      for rule in coalesce(try(var.network_access_restrictions_primary.ip_restrictions, null), []) :
+      contains(["Allow", "Deny"], rule.action)
+    ])
+    error_message = "Each ip_restrictions rule action must be either 'Allow' or 'Deny'."
+  }
+
+  validation {
+    condition = var.network_access_restrictions_primary == null || alltrue([
+      for rule in coalesce(try(var.network_access_restrictions_primary.scm_ip_restrictions, null), []) :
+      contains(["Allow", "Deny"], rule.action)
+    ])
+    error_message = "Each scm_ip_restrictions rule action must be either 'Allow' or 'Deny'."
+  }
 }
 
 variable "network_access_restrictions_certificate_master" {
@@ -465,6 +481,22 @@ variable "network_access_restrictions_certificate_master" {
       contains(["Allow", "Deny"], var.network_access_restrictions_certificate_master.scm_ip_restriction_default_action))
     )
     error_message = "ip_restriction_default_action and scm_ip_restriction_default_action must be either 'Allow' or 'Deny'."
+  }
+
+  validation {
+    condition = var.network_access_restrictions_certificate_master == null || alltrue([
+      for rule in coalesce(try(var.network_access_restrictions_certificate_master.ip_restrictions, null), []) :
+      contains(["Allow", "Deny"], rule.action)
+    ])
+    error_message = "Each ip_restrictions rule action must be either 'Allow' or 'Deny'."
+  }
+
+  validation {
+    condition = var.network_access_restrictions_certificate_master == null || alltrue([
+      for rule in coalesce(try(var.network_access_restrictions_certificate_master.scm_ip_restrictions, null), []) :
+      contains(["Allow", "Deny"], rule.action)
+    ])
+    error_message = "Each scm_ip_restrictions rule action must be either 'Allow' or 'Deny'."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -370,6 +370,104 @@ variable "manage_entra_apps" {
   default     = false
 }
 
+variable "network_access_restrictions_primary" {
+  type = object({
+    public_network_access_enabled = optional(bool)
+    ip_restriction_default_action = optional(string)
+    ip_restrictions = optional(list(object({
+      action = optional(string, "Allow")
+      headers = optional(object({
+        x_azure_fdid      = optional(set(string))
+        x_fd_health_probe = optional(set(string))
+        x_forwarded_for   = optional(set(string))
+        x_forwarded_host  = optional(set(string))
+      }))
+      ip_address                = optional(string)
+      name                      = optional(string)
+      priority                  = optional(number)
+      service_tag               = optional(string)
+      virtual_network_subnet_id = optional(string)
+    })))
+    scm_ip_restriction_default_action = optional(string)
+    scm_ip_restrictions = optional(list(object({
+      action = optional(string, "Allow")
+      headers = optional(object({
+        x_azure_fdid      = optional(set(string))
+        x_fd_health_probe = optional(set(string))
+        x_forwarded_for   = optional(set(string))
+        x_forwarded_host  = optional(set(string))
+      }))
+      ip_address                = optional(string)
+      name                      = optional(string)
+      priority                  = optional(number)
+      service_tag               = optional(string)
+      virtual_network_subnet_id = optional(string)
+    })))
+  })
+  default     = null
+  nullable    = true
+  description = "Network access restrictions for the SCEPman primary App Service. Controls public network access, inbound IP restrictions, and SCM/Kudu endpoint restrictions. When null (default), no restrictions are applied and the existing behavior is preserved."
+
+  validation {
+    condition = var.network_access_restrictions_primary == null || (
+      (try(var.network_access_restrictions_primary.ip_restriction_default_action, null) == null ||
+      contains(["Allow", "Deny"], var.network_access_restrictions_primary.ip_restriction_default_action)) &&
+      (try(var.network_access_restrictions_primary.scm_ip_restriction_default_action, null) == null ||
+      contains(["Allow", "Deny"], var.network_access_restrictions_primary.scm_ip_restriction_default_action))
+    )
+    error_message = "ip_restriction_default_action and scm_ip_restriction_default_action must be either 'Allow' or 'Deny'."
+  }
+}
+
+variable "network_access_restrictions_certificate_master" {
+  type = object({
+    public_network_access_enabled = optional(bool)
+    ip_restriction_default_action = optional(string)
+    ip_restrictions = optional(list(object({
+      action = optional(string, "Allow")
+      headers = optional(object({
+        x_azure_fdid      = optional(set(string))
+        x_fd_health_probe = optional(set(string))
+        x_forwarded_for   = optional(set(string))
+        x_forwarded_host  = optional(set(string))
+      }))
+      ip_address                = optional(string)
+      name                      = optional(string)
+      priority                  = optional(number)
+      service_tag               = optional(string)
+      virtual_network_subnet_id = optional(string)
+    })))
+    scm_ip_restriction_default_action = optional(string)
+    scm_ip_restrictions = optional(list(object({
+      action = optional(string, "Allow")
+      headers = optional(object({
+        x_azure_fdid      = optional(set(string))
+        x_fd_health_probe = optional(set(string))
+        x_forwarded_for   = optional(set(string))
+        x_forwarded_host  = optional(set(string))
+      }))
+      ip_address                = optional(string)
+      name                      = optional(string)
+      priority                  = optional(number)
+      service_tag               = optional(string)
+      virtual_network_subnet_id = optional(string)
+    })))
+  })
+  default     = null
+  nullable    = true
+  description = "Network access restrictions for the Certificate Master App Service. Controls public network access, inbound IP restrictions, and SCM/Kudu endpoint restrictions. When null (default), no restrictions are applied and the existing behavior is preserved."
+
+  validation {
+    condition = var.network_access_restrictions_certificate_master == null || (
+      (try(var.network_access_restrictions_certificate_master.ip_restriction_default_action, null) == null ||
+      contains(["Allow", "Deny"], var.network_access_restrictions_certificate_master.ip_restriction_default_action)) &&
+      (try(var.network_access_restrictions_certificate_master.scm_ip_restriction_default_action, null) == null ||
+      contains(["Allow", "Deny"], var.network_access_restrictions_certificate_master.scm_ip_restriction_default_action))
+    )
+    error_message = "ip_restriction_default_action and scm_ip_restriction_default_action must be either 'Allow' or 'Deny'."
+  }
+}
+
 variable "primary_uami_ids" {
   type        = set(string)
   description = "Set of user assigned managed identity resource IDs to assign to the SCEPman primary app service. The primary app service will always have a system assigned managed identity. This setting therefore is optional and for advanced use cases where additional user assigned managed identities need to be assigned to the app service. For most use cases, this can be left empty."


### PR DESCRIPTION
## Summary

Adds two new optional variables to control inbound network access for both App Services:
- `network_access_restrictions_primary`
- `network_access_restrictions_certificate_master`

## Problem

The module currently has no way to configure IP restrictions, SCM endpoint lockdown, or public network access control. Any manual or external configuration changes are overwritten by Terraform back to permissive defaults on the next apply.

## Solution

Each variable is a nullable optional object supporting:
- `public_network_access_enabled` — enable/disable public network access
- `ip_restriction_default_action` — deny-by-default inbound policy
- `ip_restrictions[]` — IP, subnet, service tag, and header-based rules
- `scm_ip_restriction_default_action` — deny-by-default for Kudu/SCM
- `scm_ip_restrictions[]` — same schema for the SCM endpoint

## Design Decisions

- **Backward compatible**: Both variables default to `null` — existing deployments see zero diff
- **Dynamic blocks**: Only render when configured, avoiding noisy plans
- **Per-app granularity**: Primary and Certificate Master can have independent policies
- **All fields optional**: Users only specify what they need
- **Validation**: Default actions validated to `Allow`/`Deny`
- **DRY**: Shared locals avoid repeating logic across 8 resource blocks

## Enterprise Use Cases Supported

- Deny-by-default with corporate VPN allowlist
- VNet-only access (private deployment)
- Azure Front Door backend with header validation
- SCM restricted to Azure DevOps build agents
- Fully private (`public_network_access_enabled = false`)

## Files Changed

| File | Change |
|---|---|
| `variables.tf` | New variables with optional object types + validation |
| `locals.tf` | Computed effective network configs |
| `appservices.tf` | Dynamic blocks on 4 resources |
| `appservices.full.tf` | Dynamic blocks on 4 resources |
| `examples/advanced/main.tf` | Usage example (commented) |
| `README.md` | Documentation with enterprise examples |
| `UPGRADE.md` | Migration guide |

## Testing

- `terraform fmt -check -recursive` ✅
- `terraform validate` ✅
- Zero diff confirmed when variables are unset
